### PR TITLE
Async api

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,12 @@ Currently supported platforms are:
 Where supported by the native platform APIs:
 
 * Clickable notifications
-* Notifications with buttons
-* Notifications with reply fields
-* Asyncio integration to execute callbacks on user interaction
+* Multiple action buttons
+* A single reply field (e.g., for chat notifications)
+* Asyncio integration: the main API consists of async methods and a running event loop
+  is required to respond to user interactions with a notification
 * Notification sounds
+* Notification threads (e.g., for different conversations)  
 * Limit maximum number of notifications shown in the notification center
 * Pure Python dependencies only, no extension modules
 
@@ -32,38 +34,43 @@ pip3 install -U desktop-notifier
 
 ## Usage
 
-Basic usage only requires the user to specify a notification title and message:
+The main API consists of asynchronous methods which need to be awaited. Basic usage only
+requires the user to specify a notification title and message. For instance:
 
 ```Python
+import asyncio
 from desktop_notifier import DesktopNotifier
 
-notifier = DesktopNotifier()
-n = notifier.send(title="Hello world!", message="Notification body")
+notify = DesktopNotifier()
 
-notifier.clear(n)  # removes the notification from the notification center
-notifier.clear_all()  # removes all notifications for this app
+async def main():
+    n = await notify.send(title="Hello world!", message="Sent from Python")
+
+    await notify.clear(n)  # removes the notification
+    await notify.clear_all()  # removes all notifications for this app
+
+asyncio.run(main())
 ```
 
-By default, "Python" will be used as the app name for all notifications, but you can also
-manually specify an app name and icon. Advanced usage also allows setting different
-notification options such as urgency, buttons, callbacks, etc:
+For convenience, the is also a synchronous method ``send_sync()`` to send notifications
+which does not require a running asyncio loop:
 
 ```Python
-from desktop_notifier import DesktopNotifier, NotificationLevel
+notify.send_sync(title="Hello world!", message="Sent from Python")
+```
 
-notifier = DesktopNotifier(
-    app_name="Sample App",
-    app_icon="file:///path/to/app_icon.png",
-    notification_limit=10,
-)
+By default, "Python" will be used as the app name for all notifications, but you can
+manually specify an app name and icon in the ``DesktopNotifier`` constructor. Advanced
+usage also allows setting different notification options such as urgency, buttons,
+callbacks, etc:
 
-notifier.send(
+```Python
+
+await notify.send(
     title="Julius Caesar",
     message="Et tu, Brute?",
     urgency=NotificationLevel.Critical,
-    buttons={
-        "Mark as read": lambda: print("Marked as read"),
-    },
+    buttons={"Mark as read": lambda: print("Marked as read")},
     reply_field=True,
     on_replied=lambda text: print("Brutus replied:", text),
     on_clicked=lambda: print("Notification clicked"),
@@ -72,7 +79,7 @@ notifier.send(
 )
 ```
 
-The above code will give the following result on macOS:
+The above call will give the following notification on macOS:
 
 ![gif](screenshots/macOS.gif)
 
@@ -80,17 +87,22 @@ Note that some platforms may not support all options. For instance, some Linux d
 environments may not support notifications with buttons. macOS does not support
 manually setting the app icon or name. Instead, both are always determined by the
 application which uses the Library. This can be Python itself, when used interactively,
-or a frozen app bundle when packaged with PyInstaller or similar solutions.
+or a frozen app bundle when packaged with PyInstaller or similar solutions. Please refer
+to the Platform Support chapter of the documentation for more information on limitations
+for certain platforms.
 
 Any options or configurations which are not supported by the platform will be silently
 ignored. Please refer to the documentation on [Read the Docs](https://desktop-notifier.readthedocs.io)
 for more information on platform support.
 
-Execution of callbacks requires a running event loop. On Linux, it requires a running
-[asyncio](https://docs.python.org/3/library/asyncio.html) loop and on macOS it requires
-a running
-[CFRunLoop](https://developer.apple.com/documentation/corefoundation/cfrunloop-rht). You
-can use [rubicon-objc](https://github.com/beeware/rubicon-objc) to integrate a Core
+## Event loop integration
+
+Using the asynchronous API is highly recommended to prevent multiple milliseconds of 
+blocking IO from DBus or Cocoa APIs. In addition, execution of callbacks requires a
+running event loop. On Linux, an asyncio event loop will be sufficient but macOS
+requires a running[CFRunLoop](https://developer.apple.com/documentation/corefoundation/cfrunloop-rht).
+
+You can use [rubicon-objc](https://github.com/beeware/rubicon-objc) to integrate a Core
 Foundation CFRunLoop with asyncio:
 
 ```Python
@@ -105,8 +117,15 @@ loop = asyncio.get_event_loop()
 loop.run_forever()
 ```
 
-Please refer to the [Rubicon Objective-C docs](https://rubicon-objc.readthedocs.io/en/latest/how-to/async.html)
+Desktop-notifier itself uses Rubicon Objective-C to interface with Cocoa APIs so you
+will not be adding a new dependency. A full example integrating with the CFRunLoop is
+given in [exampels/eventloop.py](exampels/eventloop.py). Please refer to the
+[Rubicon Objective-C docs](https://rubicon-objc.readthedocs.io/en/latest/how-to/async.html)
 for more information.
+
+Likewise, you can integrate the asyncio event loop with a Gtk main loop on Gnome using
+[gbulb](https://pypi.org/project/gbulb). This is not required for full functionality
+but may be convenient when developing a Gtk app.
 
 ## Notes on macOS
 

--- a/docs/background/eventloops.rst
+++ b/docs/background/eventloops.rst
@@ -1,0 +1,34 @@
+
+Event loop integration
+======================
+
+Using the asynchronous API is highly recommended to prevent multiple milliseconds of
+blocking IO from DBus or Cocoa APIs. In addition, execution of callbacks requires a
+running event loop. On Linux, an asyncio event loop will be sufficient but macOS
+requires a running[CFRunLoop](https://developer.apple.com/documentation/corefoundation/cfrunloop-rht).
+
+You can use [rubicon-objc](https://github.com/beeware/rubicon-objc) to integrate a Core
+Foundation CFRunLoop with asyncio:
+
+.. code-block:: python
+
+    import asyncio
+    from rubicon.objc.eventloop import EventLoopPolicy
+
+    # Install the event loop policy
+    asyncio.set_event_loop_policy(EventLoopPolicy())
+
+    # Get an event loop, and run it!
+    loop = asyncio.get_event_loop()
+    loop.run_forever()
+
+
+Desktop-notifier itself uses Rubicon Objective-C to interface with Cocoa APIs so you
+will not be adding a new dependency. A full example integrating with the CFRunLoop is
+given in examples folder. Please refer to the
+`Rubicon Objective-C docs <https://rubicon-objc.readthedocs.io/en/latest/how-to/async.html>`__
+for more information.
+
+Likewise, you can integrate the asyncio event loop with a Gtk main loop on Gnome using
+`gbulb <https://pypi.org/project/gbulbl>`__. This is not required for full functionality
+but may be convenient when developing a Gtk app.

--- a/examples/eventloop.py
+++ b/examples/eventloop.py
@@ -1,0 +1,35 @@
+import asyncio
+import platform
+
+from desktop_notifier import DesktopNotifier, NotificationLevel
+
+
+notifier = DesktopNotifier(
+    app_name="Sample App",
+    notification_limit=10,
+)
+
+
+async def main():
+
+    await notifier.send(
+        title="Julius Caesar",
+        message="Et tu, Brute?",
+        urgency=NotificationLevel.Critical,
+        buttons={"Mark as read": lambda: print("Marked as read")},
+        reply_field=True,
+        on_replied=lambda text: print("Brutus replied:", text),
+        on_clicked=lambda: print("Notification clicked"),
+        on_dismissed=lambda: print("Notification dismissed"),
+        sound=True,
+    )
+
+
+if platform.system() == "Darwin":
+    from rubicon.objc.eventloop import EventLoopPolicy
+
+    asyncio.set_event_loop_policy(EventLoopPolicy())
+
+loop = asyncio.get_event_loop()
+loop.create_task(main())
+loop.run_forever()

--- a/examples/synchronous.py
+++ b/examples/synchronous.py
@@ -1,0 +1,20 @@
+from desktop_notifier import DesktopNotifier, NotificationLevel
+
+
+notifier = DesktopNotifier(
+    app_name="Sample App",
+    notification_limit=10,
+)
+
+
+notifier.send_sync(
+    title="Julius Caesar",
+    message="Et tu, Brute?",
+    urgency=NotificationLevel.Critical,
+    buttons={"Mark as read": lambda: print("Marked as read")},
+    reply_field=True,
+    on_replied=lambda text: print("Brutus replied:", text),
+    on_clicked=lambda: print("Notification clicked"),
+    on_dismissed=lambda: print("Notification dismissed"),
+    sound=True,
+)

--- a/src/desktop_notifier/base.py
+++ b/src/desktop_notifier/base.py
@@ -123,9 +123,11 @@ class DesktopNotifierBase:
         self._current_notifications: Deque[Notification] = deque([], notification_limit)
         self._notification_for_nid: Dict[Union[str, int], Notification] = {}
 
-    async def request_authorisation(self) -> None:
+    async def request_authorisation(self) -> bool:
         """
         Request authorisation to send notifications.
+
+        :returns: Whether authorisation has been granted.
         """
         raise NotImplementedError()
 

--- a/src/desktop_notifier/base.py
+++ b/src/desktop_notifier/base.py
@@ -123,22 +123,19 @@ class DesktopNotifierBase:
         self._current_notifications: Deque[Notification] = deque([], notification_limit)
         self._notification_for_nid: Dict[Union[str, int], Notification] = {}
 
-    def request_authorisation(
-        self, callback: Optional[Callable[[bool, str], Any]]
-    ) -> None:
+    async def request_authorisation(self) -> None:
         """
         Request authorisation to send notifications.
         """
         raise NotImplementedError()
 
-    @property
-    def has_authorisation(self) -> bool:
+    async def has_authorisation(self) -> bool:
         """
-        Whether we have authorisation to send notifications.
+        Returns whether we have authorisation to send notifications.
         """
         raise NotImplementedError()
 
-    def send(self, notification: Notification) -> None:
+    async def send(self, notification: Notification) -> None:
         """
         Sends a desktop notification. Some arguments may be ignored, depending on the
         implementation. This is a wrapper method which mostly performs housekeeping of
@@ -159,7 +156,7 @@ class DesktopNotifierBase:
             notification_to_replace = None
 
         try:
-            platform_nid = self._send(notification, notification_to_replace)
+            platform_nid = await self._send(notification, notification_to_replace)
         except Exception:
             # Notifications can fail for many reasons:
             # The dbus service may not be available, we might be in a headless session,
@@ -189,7 +186,7 @@ class DesktopNotifierBase:
             except KeyError:
                 pass
 
-    def _send(
+    async def _send(
         self,
         notification: Notification,
         notification_to_replace: Optional[Notification],
@@ -216,7 +213,7 @@ class DesktopNotifierBase:
         """
         return list(self._current_notifications)
 
-    def clear(self, notification: Notification) -> None:
+    async def clear(self, notification: Notification) -> None:
         """
         Removes the given notification from the notification center. This is a wrapper
         method which mostly performs housekeeping of notifications ID and calls
@@ -227,11 +224,11 @@ class DesktopNotifierBase:
         """
 
         if notification.identifier:
-            self._clear(notification)
+            await self._clear(notification)
 
         self._clear_notification_from_cache(notification)
 
-    def _clear(self, notification: Notification) -> None:
+    async def _clear(self, notification: Notification) -> None:
         """
         Removes the given notification from the notification center. Should be
         implemented by subclasses.
@@ -240,7 +237,7 @@ class DesktopNotifierBase:
         """
         raise NotImplementedError()
 
-    def clear_all(self) -> None:
+    async def clear_all(self) -> None:
         """
         Clears all notifications from the notification center. This is a wrapper method
         which mostly performs housekeeping of notifications ID and calls
@@ -248,11 +245,11 @@ class DesktopNotifierBase:
         must implement :meth:`_clear_all`.
         """
 
-        self._clear_all()
+        await self._clear_all()
         self._current_notifications.clear()
         self._notification_for_nid.clear()
 
-    def _clear_all(self) -> None:
+    async def _clear_all(self) -> None:
         """
         Clears all notifications from the notification center. Should be implemented by
         subclasses.

--- a/src/desktop_notifier/dbus.py
+++ b/src/desktop_notifier/dbus.py
@@ -59,11 +59,13 @@ class DBusDesktopNotifier(DesktopNotifierBase):
         super().__init__(app_name, app_icon, notification_limit)
         self.interface: Optional[ProxyInterface] = None
 
-    async def request_authorisation(self) -> None:
+    async def request_authorisation(self) -> bool:
         """
         Request authorisation to send notifications.
+
+        :returns: Whether authorisation has been granted.
         """
-        pass
+        return True
 
     async def has_authorisation(self) -> bool:
         """

--- a/src/desktop_notifier/dbus.py
+++ b/src/desktop_notifier/dbus.py
@@ -6,9 +6,8 @@ event loop.
 """
 
 # system imports
-import asyncio
 import logging
-from typing import Optional, Coroutine, TypeVar, Callable
+from typing import Optional, TypeVar
 
 # external imports
 from dbus_next import Variant  # type: ignore
@@ -58,35 +57,19 @@ class DBusDesktopNotifier(DesktopNotifierBase):
         notification_limit: Optional[int] = None,
     ) -> None:
         super().__init__(app_name, app_icon, notification_limit)
-        self._loop = asyncio.get_event_loop()
         self.interface: Optional[ProxyInterface] = None
 
-    def request_authorisation(self, callback: Optional[Callable]) -> None:
+    async def request_authorisation(self) -> None:
         """
         Request authorisation to send notifications.
         """
-        if callback:
-            callback(True, "")
+        pass
 
-    @property
-    def has_authorisation(self) -> bool:
+    async def has_authorisation(self) -> bool:
         """
         Whether we have authorisation to send notifications.
         """
         return True
-
-    def _run_coco_sync(self, coro: Coroutine[None, None, T]) -> T:
-        """
-        Runs the given coroutine and returns the result synchronously.
-        """
-
-        if self._loop.is_running():
-            future = asyncio.run_coroutine_threadsafe(coro, self._loop)
-            res = future.result()
-        else:
-            res = self._loop.run_until_complete(coro)
-
-        return res
 
     async def _init_dbus(self) -> ProxyInterface:
 
@@ -113,22 +96,7 @@ class DBusDesktopNotifier(DesktopNotifierBase):
 
         return self.interface
 
-    def _send(
-        self,
-        notification: Notification,
-        notification_to_replace: Optional[Notification],
-    ) -> int:
-        """
-        Synchronously sends a notification via the Dbus interface.
-
-        :param notification: Notification to send.
-        :param notification_to_replace: Notification to replace, if any.
-        """
-        return self._run_coco_sync(
-            self._send_async(notification, notification_to_replace)
-        )
-
-    async def _send_async(
+    async def _send(
         self,
         notification: Notification,
         notification_to_replace: Optional[Notification],
@@ -177,15 +145,7 @@ class DBusDesktopNotifier(DesktopNotifierBase):
 
         return platform_nid
 
-    def _clear(self, notification: Notification) -> None:
-        """
-        Synchronously removes a notifications from the notification center
-
-        :param notification: Notification to clear.
-        """
-        self._run_coco_sync(self._clear_async(notification))
-
-    async def _clear_async(self, notification: Notification) -> None:
+    async def _clear(self, notification: Notification) -> None:
         """
         Asynchronously removes a notification from the notification center
         """
@@ -195,19 +155,7 @@ class DBusDesktopNotifier(DesktopNotifierBase):
 
         await self.interface.call_close_notification(notification.identifier)
 
-    def _clear_all(self) -> None:
-        """
-        Synchronously clears all notifications from notification center
-
-        The org.freedesktop.Notifications specification does not support retrieving or
-        or clearing all notifications for an app name directly. We therefore rely on our
-        cache of already delivered notifications and clear them individually. Since this
-        is not persistent between Python sessions, notifications delivered in a previous
-        session will not be cleared.
-        """
-        self._run_coco_sync(self._clear_all_async())
-
-    async def _clear_all_async(self) -> None:
+    async def _clear_all(self) -> None:
         """
         Asynchronously clears all notifications from notification center
         """

--- a/src/desktop_notifier/dummy.py
+++ b/src/desktop_notifier/dummy.py
@@ -22,11 +22,13 @@ class DummyNotificationCenter(DesktopNotifierBase):
     ) -> None:
         super().__init__(app_name, app_icon, notification_limit)
 
-    async def request_authorisation(self) -> None:
+    async def request_authorisation(self) -> bool:
         """
         Request authorisation to send notifications.
+
+        :returns: Whether authorisation has been granted.
         """
-        pass
+        return True
 
     async def has_authorisation(self) -> bool:
         """

--- a/src/desktop_notifier/dummy.py
+++ b/src/desktop_notifier/dummy.py
@@ -5,7 +5,7 @@ Dummy backend for unsupported platforms.
 
 # system imports
 import uuid
-from typing import Optional, Callable, Any
+from typing import Optional
 
 # local imports
 from .base import Notification, DesktopNotifierBase
@@ -22,23 +22,19 @@ class DummyNotificationCenter(DesktopNotifierBase):
     ) -> None:
         super().__init__(app_name, app_icon, notification_limit)
 
-    def request_authorisation(
-        self, callback: Optional[Callable[[bool, str], Any]]
-    ) -> None:
+    async def request_authorisation(self) -> None:
         """
         Request authorisation to send notifications.
         """
-        if callback:
-            callback(True, "")
+        pass
 
-    @property
-    def has_authorisation(self) -> bool:
+    async def has_authorisation(self) -> bool:
         """
         Whether we have authorisation to send notifications.
         """
         return True
 
-    def _send(
+    async def _send(
         self,
         notification: Notification,
         notification_to_replace: Optional[Notification],
@@ -48,8 +44,8 @@ class DummyNotificationCenter(DesktopNotifierBase):
         else:
             return str(uuid.uuid4())
 
-    def _clear(self, notification: Notification) -> None:
+    async def _clear(self, notification: Notification) -> None:
         pass
 
-    def _clear_all(self) -> None:
+    async def _clear_all(self) -> None:
         pass

--- a/src/desktop_notifier/macos.py
+++ b/src/desktop_notifier/macos.py
@@ -15,6 +15,7 @@ import uuid
 import logging
 import enum
 import asyncio
+from concurrent.futures import Future
 from typing import Optional, Callable, Any, cast
 
 # external imports
@@ -190,8 +191,7 @@ class CocoaNotificationCenter(DesktopNotifierBase):
 
         # Get existing notification categories.
 
-        loop = asyncio.get_event_loop()
-        future = loop.create_future()
+        future: Future = Future()
 
         def handler(settings: objc_id) -> None:
             settings = py_from_ns(settings)
@@ -200,7 +200,7 @@ class CocoaNotificationCenter(DesktopNotifierBase):
 
         self.nc.getNotificationSettingsWithCompletionHandler(handler)
 
-        settings = await future
+        settings = await asyncio.wrap_future(future)
 
         authorized = settings.authorizationStatus in (
             UNAuthorizationStatusAuthorized,
@@ -254,8 +254,7 @@ class CocoaNotificationCenter(DesktopNotifierBase):
             platform_nid, content=content, trigger=None
         )
 
-        loop = asyncio.get_event_loop()
-        future = loop.create_future()
+        future: Future = Future()
 
         def handler(error: objc_id) -> None:
             ns_error = py_from_ns(error)
@@ -270,7 +269,7 @@ class CocoaNotificationCenter(DesktopNotifierBase):
 
         # Error handling.
 
-        error = await future
+        error = await asyncio.wrap_future(future)
 
         if error:
             error.autorelease()
@@ -357,8 +356,7 @@ class CocoaNotificationCenter(DesktopNotifierBase):
     async def _get_notification_categories(self) -> NSSet:  # type: ignore
         """Returns the registered notification categories for this app / Python."""
 
-        loop = asyncio.get_event_loop()
-        future = loop.create_future()
+        future: Future = Future()
 
         def handler(categories: objc_id) -> None:
             categories = py_from_ns(categories)
@@ -367,7 +365,7 @@ class CocoaNotificationCenter(DesktopNotifierBase):
 
         self.nc.getNotificationCategoriesWithCompletionHandler(handler)
 
-        categories = await future
+        categories = await asyncio.wrap_future(future)
         categories.autorelease()
 
         return categories

--- a/src/desktop_notifier/macos_legacy.py
+++ b/src/desktop_notifier/macos_legacy.py
@@ -12,7 +12,7 @@ NSUserNotificationCenter backend for macOS.
 import uuid
 import platform
 import logging
-from typing import Optional, Callable, Any, cast
+from typing import Optional, cast
 
 # external imports
 from rubicon.objc import NSObject, ObjCClass, objc_method, py_from_ns  # type: ignore
@@ -103,23 +103,19 @@ class CocoaNotificationCenterLegacy(DesktopNotifierBase):
         self.nc_delegate.interface = self
         self.nc.delegate = self.nc_delegate
 
-    def request_authorisation(
-        self, callback: Optional[Callable[[bool, str], Any]]
-    ) -> None:
+    async def request_authorisation(self) -> None:
         """
         Request authorisation to send notifications.
         """
-        if callback:
-            callback(True, "")
+        pass
 
-    @property
-    def has_authorisation(self) -> bool:
+    async def has_authorisation(self) -> bool:
         """
         Whether we have authorisation to send notifications.
         """
         return True
 
-    def _send(
+    async def _send(
         self,
         notification: Notification,
         notification_to_replace: Optional[Notification],
@@ -160,7 +156,7 @@ class CocoaNotificationCenterLegacy(DesktopNotifierBase):
 
         return platform_nid
 
-    def _clear(self, notification: Notification) -> None:
+    async def _clear(self, notification: Notification) -> None:
         """
         Removes a notifications from the notification center
 
@@ -170,7 +166,7 @@ class CocoaNotificationCenterLegacy(DesktopNotifierBase):
         if hasattr(notification, "_native"):
             self.nc.removeDeliveredNotification(notification._native)  # type: ignore
 
-    def _clear_all(self) -> None:
+    async def _clear_all(self) -> None:
         """
         Clears all notifications from notification center
         """

--- a/src/desktop_notifier/macos_legacy.py
+++ b/src/desktop_notifier/macos_legacy.py
@@ -103,11 +103,13 @@ class CocoaNotificationCenterLegacy(DesktopNotifierBase):
         self.nc_delegate.interface = self
         self.nc.delegate = self.nc_delegate
 
-    async def request_authorisation(self) -> None:
+    async def request_authorisation(self) -> bool:
         """
         Request authorisation to send notifications.
+
+        :returns: Whether authorisation has been granted.
         """
-        pass
+        return True
 
     async def has_authorisation(self) -> bool:
         """

--- a/src/desktop_notifier/main.py
+++ b/src/desktop_notifier/main.py
@@ -114,9 +114,7 @@ class DesktopNotifier:
         """Setter: app_icon"""
         self._impl.app_icon = value
 
-    def request_authorisation(
-        self, callback: Optional[Callable[[bool, str], Any]] = None
-    ) -> None:
+    async def request_authorisation(self) -> None:
         """
         Requests authorisation to send user notifications. This will be automatically
         called for you when sending a notification for the first time but it may be
@@ -126,26 +124,17 @@ class DesktopNotifier:
         when this method is called for the first time. This method does nothing on
         platforms where user authorisation is not required.
 
-        This method returns immediately. You can provide a callback to run once
-        authorisation has been granted or rejected and use :attr:`has_authorisation` to
-        verify permissions.
-
-        :param callback: A method to call when the authorisation request has been
-            granted or denied. The callback will be called with two arguments: a bool
-            indicating if authorisation was granted and a string describing failure
-            reasons for the request.
         """
 
         with self._lock:
             self._did_request_authorisation = True
-            self._impl.request_authorisation(callback)
+            await self._impl.request_authorisation()
 
-    @property
-    def has_authorisation(self) -> bool:
-        """Whether we have authorisation to send notifications."""
-        return self._impl.has_authorisation
+    async def has_authorisation(self) -> bool:
+        """Returns whether we have authorisation to send notifications."""
+        return await self._impl.has_authorisation()
 
-    def send(
+    async def send(
         self,
         title: str,
         message: str,
@@ -216,9 +205,9 @@ class DesktopNotifier:
         with self._lock:
 
             if not self._did_request_authorisation:
-                self.request_authorisation()
+                await self.request_authorisation()
 
-            self._impl.send(notification)
+            await self._impl.send(notification)
 
         return notification
 
@@ -227,19 +216,19 @@ class DesktopNotifier:
         """A list of all currently displayed notifications for this app"""
         return self._impl.current_notifications
 
-    def clear(self, notification: Notification) -> None:
+    async def clear(self, notification: Notification) -> None:
         """
         Removes the given notification from the notification center.
 
         :param notification: Notification to clear.
         """
         with self._lock:
-            self._impl.clear(notification)
+            await self._impl.clear(notification)
 
-    def clear_all(self) -> None:
+    async def clear_all(self) -> None:
         """
         Removes all currently displayed notifications for this app from the notification
         center.
         """
         with self._lock:
-            self._impl.clear_all()
+            await self._impl.clear_all()

--- a/src/desktop_notifier/main.py
+++ b/src/desktop_notifier/main.py
@@ -114,7 +114,7 @@ class DesktopNotifier:
         """Setter: app_icon"""
         self._impl.app_icon = value
 
-    async def request_authorisation(self) -> None:
+    async def request_authorisation(self) -> bool:
         """
         Requests authorisation to send user notifications. This will be automatically
         called for you when sending a notification for the first time but it may be
@@ -124,11 +124,12 @@ class DesktopNotifier:
         when this method is called for the first time. This method does nothing on
         platforms where user authorisation is not required.
 
+        :returns: Whether authorisation has been granted.
         """
 
         with self._lock:
             self._did_request_authorisation = True
-            await self._impl.request_authorisation()
+            return await self._impl.request_authorisation()
 
     async def has_authorisation(self) -> bool:
         """Returns whether we have authorisation to send notifications."""
@@ -209,7 +210,7 @@ class DesktopNotifier:
 
             await self._impl.send(notification)
 
-        return notification
+            return notification
 
     @property
     def current_notifications(self) -> List[Notification]:


### PR DESCRIPTION
Closes #3 by fully moving to an asyncio API.

For convenience, the synchronous equivalent `DesktopNotifier.send_sync()` is provided for `DesktopNotifier.send()`.