### PR TITLE
Windows backend

### DIFF
--- a/docs/background/platform_support.rst
+++ b/docs/background/platform_support.rst
@@ -3,39 +3,49 @@ Platform support
 ================
 
 Some platforms may not support all options. For instance, some Linux desktop
-environments may not support notifications with buttons. macOS does not support
+environments may not support notifications with buttons. macOS and Windows do not support
 manually setting the app icon or name. Instead, both are always determined by the
 application which uses the Library. This can be Python itself, when used interactively,
 or a frozen app bundle when packaged with PyInstaller or similar solutions.
 
 The table below gives an overview over supported functionality for different platforms.
+Please refer to the platform documentation for more detailed information:
+
+* macOS: https://developer.apple.com/documentation/usernotifications/unusernotificationcenter
+* Linux: https://specifications.freedesktop.org/notification-spec/notification-spec-latest.html
+* Windows: https://docs.microsoft.com/windows/apps/design/shell/tiles-and-notifications/adaptive-interactive-toasts
+
+.. note:: Windows support is still experimental and may have some rough edges.
 
 .. csv-table::
-   :header: "Option", "Description", "Linux", "macOS/iOS"
+   :header: "Option", "Description", "Linux", "macOS/iOS", Windows
    :widths: 5, 5, 5, 5
 
-   "app_name", "The application name to display", "✓", "-- [#f1]_"
-   "app_icon", "The icon shown with the notification", "✓", "-- [#f1]_"
-   "title", "The notification title", "✓", "✓"
-   "message", "The notification message", "✓", "✓"
-   "urgency", "Level that determines how the notification is displayed", "✓", "✓ [#f2]_"
-   "buttons", "One or more buttons with callbacks", "✓ [#f3]_", "✓ [#f4]_"
-   "reply_field", "A reply field instance to show with the notification", "--", "✓"
-   "on_clicked", "A callback to invoke when the notification is clicked", "✓ [#f3]_", "✓"
-   "on_dismissed", "A callback to invoke when the notification is dismissed", "✓ [#f3]_", "✓"
-   "sound", "Play a default sound when showing the notification", "✓ [#f3]_", "✓"
-   "thread", "An identifier to group notifications together", "--", "✓"
+   "app_name", "The application name to display", "✓", "-- [#f1]_", "-- [#f1]_"
+   "app_icon", "The icon shown with the notification", "✓", "-- [#f1]_", "-- [#f1]_"
+   "title", "The notification title", "✓", "✓", "✓"
+   "message", "The notification message", "✓", "✓", "✓"
+   "urgency", "Level that determines how the notification is displayed", "✓", "✓ [#f2]_", "✓"
+   "buttons", "One or more buttons with callbacks", "✓ [#f3]_", "✓ [#f4]_", "✓"
+   "reply_field", "A reply field instance to show with the notification", "--", "✓", "✓"
+   "on_clicked", "A callback to invoke when the notification is clicked", "✓ [#f3]_", "✓", "✓"
+   "on_dismissed", "A callback to invoke when the notification is dismissed", "✓ [#f3]_", "✓", "✓"
+   "sound", "Play a default sound when showing the notification", "✓ [#f3]_", "✓", "✓"
+   "thread", "An identifier to group notifications together", "--", "✓", "✓"
+   "attachment", "A file, e.g., image, attached to the notification", "✓ [#f5]_", "✓ [#f5]_", "✓ [#f5]_"
 
-.. [#f1] App name and icon on macOS are automatically determined by the calling application.
+.. [#f1] App name and icon on macOS and Windows are automatically determined by the
+         calling application.
 .. [#f2] Only on macOS 12 and later.
 .. [#f3] May be ignored by some notification servers, depending on the desktop environment.
 .. [#f4] Only a single button is supported by our implementation for macOS 10.13 and lower.
+.. [#f5] Limitations on file types exist for each platform.
 
 Callbacks
 *********
 
-MacOS and almost all Linux notification servers support executing a callback when the
-notification is clicked. Note the requirements on a running event loop to handle
+MacOS, Windows and almost all Linux notification servers support executing a callback when
+the notification is clicked. Note the requirements on a running event loop to handle
 callbacks in Python.
 
 Urgency
@@ -57,6 +67,8 @@ macOS 10.14+, we support an unlimited number of buttons.
 Linux desktop environments and notification servers may or may not support a varying
 number of buttons. Gnome desktops typically support up to three buttons.
 
+Windows supports up to 5 buttons.
+
 When an implementation or a platform supports only a limited number of buttons, any
 additional buttons specified in the notification request will be silently ignored.
 
@@ -73,6 +85,9 @@ preview of the file. Allowed file types are:
 On macOS, only previews of image attachments will be shown. iOS will show previews of
 all of the above attachment types and allows long-pressing the notification to show the
 full attachment. The notification will still be shown if the attachment cannot be loaded.
+
+Windows supports images only. The image URI must be a web url or point to a resource
+bundled with the app.
 
 Linux notification servers may support attaching a secondary image to the notification,
 shown in addition to the app icon. Where this is not supported, the app icon will be

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,6 +32,7 @@ install_requires =
     importlib_resources;python_version<'3.9'
     packaging
     rubicon-objc;sys_platform=='darwin'
+    winsdk;sys_platform=='win32'
 python_requires = >=3.6
 
 [options.packages.find]

--- a/src/desktop_notifier/main.py
+++ b/src/desktop_notifier/main.py
@@ -109,6 +109,13 @@ def get_implementation() -> Type[DesktopNotifierBase]:
 
         return DBusDesktopNotifier
 
+    elif platform.system() == "Windows" and Version(platform.version()) >= Version(
+        "10.0.10240"
+    ):
+        from .winrt import WinRTDesktopNotifier
+
+        return WinRTDesktopNotifier
+
     else:
         from .dummy import DummyNotificationCenter
 

--- a/src/desktop_notifier/winrt.py
+++ b/src/desktop_notifier/winrt.py
@@ -1,0 +1,181 @@
+# -*- coding: utf-8 -*-
+"""
+Notification backend for Linux. Includes an implementation to send desktop notifications
+over Dbus. Responding to user interaction with a notification requires a running asyncio
+event loop.
+"""
+
+# system imports
+import sys
+import uuid
+import logging
+from xml.etree.ElementTree import Element, SubElement, tostring
+from typing import Optional, TypeVar, cast
+
+# external imports
+import winrt.windows.ui.notifications as notifications
+import winrt.windows.data.xml.dom as dom
+
+# local imports
+from .base import Notification, DesktopNotifierBase, Urgency
+
+
+__all__ = ["WinRTDesktopNotifier"]
+
+logger = logging.getLogger(__name__)
+
+T = TypeVar("T")
+
+
+class WinRTDesktopNotifier(DesktopNotifierBase):
+    """DBus notification backend for Linux
+
+    This implements the org.freedesktop.Notifications standard. The DBUS connection is
+    created in a thread with a running asyncio loop to handle clicked notifications.
+
+    :param app_name: The name of the app. If it matches the application name in an
+        existing desktop entry, the icon from that entry will be used by default.
+    :param app_icon: The default icon to use for notifications. Will take precedence
+        over any icon from the desktop file. Should be a URI or a name in a
+        freedesktop.org-compliant icon theme.
+    :param notification_limit: Maximum number of notifications to keep in the system's
+        notification center.
+    """
+
+    _to_native_urgency = {
+        Urgency.Low: notifications.ToastNotificationPriority.DEFAULT,
+        Urgency.Normal: notifications.ToastNotificationPriority.DEFAULT,
+        Urgency.Critical: notifications.ToastNotificationPriority.HIGH,
+    }
+
+    def __init__(
+        self,
+        app_name: str = "Python",
+        app_icon: Optional[str] = None,
+        notification_limit: Optional[int] = None,
+    ) -> None:
+        super().__init__(app_name, app_icon, notification_limit)
+        self.manager = notifications.ToastNotificationManager.get_default()
+        self.notifier = self.manager.create_toast_notifier(sys.executable)
+
+    async def request_authorisation(self) -> bool:
+        """
+        Request authorisation to send notifications.
+
+        :returns: Whether authorisation has been granted.
+        """
+        return await self.has_authorisation()
+
+    async def has_authorisation(self) -> bool:
+        """
+        Whether we have authorisation to send notifications.
+        """
+        return self.notifier.setting == notifications.NotificationSetting.ENABLED
+
+    async def _send(
+        self,
+        notification: Notification,
+        notification_to_replace: Optional[Notification],
+    ) -> str:
+        """
+        Asynchronously sends a notification via the Dbus interface.
+
+        :param notification: Notification to send.
+        :param notification_to_replace: Notification to replace, if any.
+        """
+
+        if notification_to_replace:
+            platform_nid = cast(str, notification_to_replace.identifier)
+        else:
+            platform_nid = str(uuid.uuid4())
+
+        # Create notification XML.
+        toast_xml = Element("toast", {"launch": "default"})
+        visual_xml = SubElement(toast_xml, "visual")
+        actions_xml = SubElement(toast_xml, "actions")
+
+        if notification.thread:
+            SubElement(
+                toast_xml,
+                "header",
+                {"id": notification.thread, "title": notification.thread},
+            )
+
+        binding = SubElement(visual_xml, "binding", {"template": "ToastGeneric"})
+
+        title_xml = SubElement(binding, "text")
+        title_xml.text = notification.title
+
+        message_xml = SubElement(binding, "text")
+        message_xml.text = notification.message
+
+        if notification.icon:
+            SubElement(
+                binding,
+                "image",
+                {"placement": "appLogoOverride", "src": notification.icon},
+            )
+
+        if notification.attachment:
+            SubElement(
+                binding, "image", {"placement": "hero", "src": notification.attachment}
+            )
+
+        if notification.reply_field:
+            SubElement(actions_xml, "input", {"id": "textBox", "type": "text"})
+            SubElement(
+                actions_xml,
+                "action",
+                {
+                    "content": notification.reply_field.button_title,
+                    "activationType": "background",
+                    "arguments": "action=reply",
+                },
+            )
+
+        for n, button in enumerate(notification.buttons):
+            SubElement(
+                actions_xml,
+                "action",
+                {
+                    "content": button.title,
+                    "activationType": "background",
+                    "arguments": f"action={n}",
+                },
+            )
+
+        if notification.sound:
+            SubElement(
+                toast_xml, "audio", {"src": "ms-winsoundevent:Notification.Default"}
+            )
+        else:
+            SubElement(toast_xml, "audio", {"silent": "true"})
+
+        xml_document = dom.XmlDocument()
+        xml_document.load_xml(tostring(toast_xml, encoding="unicode"))
+
+        native = notifications.ToastNotification(xml_document)
+        native.tag = platform_nid
+        native.priority = self._to_native_urgency[notification.urgency]
+
+        if notification.thread:
+            native.group = notification.thread
+        else:
+            native.group = "default"
+
+        self.notifier.show(native)
+
+        return platform_nid
+
+    async def _clear(self, notification: Notification) -> None:
+        """c
+        Asynchronously removes a notification from the notification center
+        """
+        group = notification.thread or "default"
+        self.manager.history.remove(notification.identifier, group, sys.executable)
+
+    async def _clear_all(self) -> None:
+        """
+        Asynchronously clears all notifications from notification center
+        """
+        self.manager.history.clear(sys.executable)

--- a/src/desktop_notifier/winrt.py
+++ b/src/desktop_notifier/winrt.py
@@ -14,7 +14,7 @@ from xml.etree.ElementTree import Element, SubElement, tostring
 from typing import Optional, TypeVar, cast
 
 # external imports
-from winrt.windows.ui.notifications import (
+from winsdk.windows.ui.notifications import (
     ToastNotificationManager,
     ToastNotificationPriority,
     NotificationSetting,
@@ -22,15 +22,15 @@ from winrt.windows.ui.notifications import (
     ToastActivatedEventArgs,
     ToastDismissalReason,
 )
-from winrt.windows.data.xml import dom
-from winrt.windows.applicationmodel.core import CoreApplication
-from winrt.windows.applicationmodel.background import (
+from winsdk.windows.data.xml import dom
+from winsdk.windows.applicationmodel.core import CoreApplication
+from winsdk.windows.applicationmodel.background import (
     BackgroundTaskRegistration,
     BackgroundTaskBuilder,
     BackgroundExecutionManager,
     ToastNotificationActionTrigger,
 )
-from winrt.windows.foundation import IPropertyValue, PropertyType
+from winsdk.windows.foundation import IPropertyValue, PropertyType
 
 # local imports
 from .base import Notification, DesktopNotifierBase, Urgency

--- a/src/desktop_notifier/winrt.py
+++ b/src/desktop_notifier/winrt.py
@@ -162,16 +162,20 @@ class WinRTDesktopNotifier(DesktopNotifierBase):
 
         if notification.reply_field:
             SubElement(actions_xml, "input", {"id": "textBox", "type": "text"})
-            SubElement(
+            reply_button_xml = SubElement(
                 actions_xml,
                 "action",
                 {
                     "content": notification.reply_field.button_title,
                     "activationType": "background",
                     "arguments": "action=reply&amp",
-                    "hint-inputId": "textBox",
                 },
             )
+
+            # If there are no other buttons, show the
+            # reply buttons next to the text field.
+            if not notification.buttons:
+                reply_button_xml.set("hint-inputId", "textBox")
 
         for n, button in enumerate(notification.buttons):
             SubElement(


### PR DESCRIPTION
This PR introduces support for Windows using Microsoft's Python/WinRT bridge. Closes #1.

This PR introduces a dependency on [winrt](https://pypi.org/project/winrt/) with binary components. This is necessary for interaction with the Windows Runtime and therefore rich notification. The alternative would be support for "plain" notifications with a title and message only as provided by the winapi. The latter can be accessed via FFI / ctypes. See the discussion in #1.

Todo:

- [x] Wait for a new Python/WinRT release with support for the SDK version 18362 (https://github.com/microsoft/xlang/pull/744).
- [x] Update documentation.
