### PR TITLE
Improve macOS backend selection

### DIFF
--- a/src/desktop_notifier/macos_support.py
+++ b/src/desktop_notifier/macos_support.py
@@ -1,0 +1,76 @@
+# -*- coding: utf-8 -*-
+"""
+Support module for macOS.
+
+"""
+
+import ctypes
+
+from rubicon.objc import ObjCClass
+from rubicon.objc.runtime import load_library
+
+
+__all__ = [
+    "is_bundle",
+    "is_signed_bundle",
+]
+
+
+sec = load_library("Security")
+foundation = load_library("Foundation")
+
+NSBundle = ObjCClass("NSBundle")
+
+# Security/SecRequirement.h
+
+kSecCSDefaultFlags = 0
+kSecCSCheckAllArchitectures = 1 << 0
+kSecCSDoNotValidateExecutable = 1 << 1
+kSecCSDoNotValidateResources = 1 << 2
+kSecCSCheckNestedCode = 1 << 3
+kSecCSStrictValidate = 1 << 4
+
+
+def is_bundle() -> bool:
+    """
+    Detect if we are in an app bundle / framework.
+
+    :returns: Whether we are inside a valid app bundle or framework.
+    """
+
+    main_bundle = NSBundle.mainBundle
+
+    return main_bundle.bundleIdentifier is not None
+
+
+def is_signed_bundle() -> bool:
+    """
+    Detect if we are in a signed app bundle / framework.
+
+    :returns: Whether we are inside a signed app bundle or framework.
+    """
+
+    main_bundle = NSBundle.mainBundle
+
+    if main_bundle.bundleIdentifier is None:
+        return False
+
+    # Check for valid signature.
+
+    static_code = ctypes.c_void_p(0)
+
+    err = sec.SecStaticCodeCreateWithPath(
+        main_bundle.bundleURL, kSecCSDefaultFlags, ctypes.byref(static_code)
+    )
+
+    if err != 0:
+        return False
+
+    signed_status = sec.SecStaticCodeCheckValidityWithErrors(
+        static_code,
+        kSecCSCheckAllArchitectures | kSecCSCheckNestedCode | kSecCSStrictValidate,
+        None,
+        None,
+    )
+
+    return signed_status == 0


### PR DESCRIPTION
This PR improves the selection of the macOS backend by detecting if we are running from a (signed) app bundle or framework. The selection will now be performed as follows:

1. macOS 12 and later: Use `UNUserNotificationCenter` from inside a signed app bundle or framework, dummy backend otherwise.
2. macOS 10.14 to 11: Use `UNUserNotificationCenter` from inside a signed app bundle or framework, `NSUserNotificationCenter` from inside an unsigned app bundle or framework, dummy backend otherwise.
3. macOS 10.13 and earlier: Use `NSUserNotificationCenter` from inside an app bundle or framework (signed or unsigned), dummy backend otherwise.

The keyword argument `macos_legacy` is removed from `DesktopNotifier.__init__()`. Backend selection will always be automatic.

Fixes #8.