### PR TITLE
[Windows] fix: unbox_winrt value checking

### DIFF
--- a/src/desktop_notifier/winrt.py
+++ b/src/desktop_notifier/winrt.py
@@ -268,15 +268,15 @@ def unbox_winrt(boxed_value):
 
     value = IPropertyValue._from(boxed_value)
 
-    if value.type is PropertyType.EMPTY.value:
+    if value.type is PropertyType.EMPTY:
         return None
-    elif value.type is PropertyType.UINT8.value:
+    elif value.type is PropertyType.UINT8:
         return value.get_uint8()
-    elif value.type is PropertyType.INT16.value:
+    elif value.type is PropertyType.INT16:
         return value.get_int16()
-    elif value.type is PropertyType.UINT16.value:
+    elif value.type is PropertyType.UINT16:
         return value.get_uint16()
-    elif value.type is PropertyType.STRING.value:
+    elif value.type is PropertyType.STRING:
         return value.get_string()
     else:
         raise NotImplementedError(f"Unboxing {value.type} is not yet supported")


### PR DESCRIPTION
When using `unbox_winrt` in winrt.py, the function almost always raises NotImplementedError.

This is because of the if statement checks:
https://github.com/samschott/desktop-notifier/blob/0e1ff41fd2e2510a9d776ed2cf8b142d79eb9b9e/src/desktop_notifier/winrt.py#L271-L282

checking IntEnum values with `is` keyword and using redundant `.value`
I removed the extra `.value` in if checks.
```diff
...
-    elif value.type is PropertyType.INT16.value:
+    elif value.type is PropertyType.INT16:
...
```

***Brutus replied: hi 😎***