### PR TITLE
Support registering a custom app ID if we cannot auto-detect one

### DIFF
--- a/src/desktop_notifier/base.py
+++ b/src/desktop_notifier/base.py
@@ -171,7 +171,6 @@ class DesktopNotifierBase:
     """Base class for desktop notifier implementations
 
     :param app_name: Name to identify the application in the notification center.
-    :param app_icon: Default icon to use for notifications.
     :param notification_limit: Maximum number of notifications to keep in the system's
         notification center.
     """
@@ -179,11 +178,9 @@ class DesktopNotifierBase:
     def __init__(
         self,
         app_name: str = "Python",
-        app_icon: Optional[str] = None,
         notification_limit: Optional[int] = None,
     ) -> None:
         self.app_name = app_name
-        self.app_icon = app_icon
         self.notification_limit = notification_limit
         self._current_notifications: Deque[Notification] = deque([], notification_limit)
         self._notification_for_nid: Dict[Union[str, int], Notification] = {}

--- a/src/desktop_notifier/base.py
+++ b/src/desktop_notifier/base.py
@@ -66,7 +66,9 @@ class Button:
     """
 
     def __init__(
-        self, title: str, on_pressed: Optional[Callable[[], Any]] = None
+        self,
+        title: str,
+        on_pressed: Optional[Callable[[], Any]] = None,
     ) -> None:
         self.title = title
         self.on_pressed = on_pressed

--- a/src/desktop_notifier/dbus.py
+++ b/src/desktop_notifier/dbus.py
@@ -53,10 +53,9 @@ class DBusDesktopNotifier(DesktopNotifierBase):
     def __init__(
         self,
         app_name: str = "Python",
-        app_icon: Optional[str] = None,
         notification_limit: Optional[int] = None,
     ) -> None:
-        super().__init__(app_name, app_icon, notification_limit)
+        super().__init__(app_name, notification_limit)
         self.interface: Optional[ProxyInterface] = None
 
     async def request_authorisation(self) -> bool:

--- a/src/desktop_notifier/dummy.py
+++ b/src/desktop_notifier/dummy.py
@@ -17,10 +17,9 @@ class DummyNotificationCenter(DesktopNotifierBase):
     def __init__(
         self,
         app_name: str = "Python",
-        app_icon: Optional[str] = None,
         notification_limit: Optional[int] = None,
     ) -> None:
-        super().__init__(app_name, app_icon, notification_limit)
+        super().__init__(app_name, notification_limit)
 
     async def request_authorisation(self) -> bool:
         """

--- a/src/desktop_notifier/macos.py
+++ b/src/desktop_notifier/macos.py
@@ -144,8 +144,6 @@ class CocoaNotificationCenter(DesktopNotifierBase):
 
     :param app_name: The name of the app. Does not have any effect because the app
         name is automatically determined from the bundle or framework.
-    :param app_icon: The icon of the app. Does not have any effect because the app
-        icon is automatically determined from the bundle or framework.
     :param notification_limit: Maximum number of notifications to keep in the system's
         notification center.
     """
@@ -159,10 +157,9 @@ class CocoaNotificationCenter(DesktopNotifierBase):
     def __init__(
         self,
         app_name: str = "Python",
-        app_icon: Optional[str] = None,
         notification_limit: Optional[int] = None,
     ) -> None:
-        super().__init__(app_name, app_icon, notification_limit)
+        super().__init__(app_name, notification_limit)
         self.nc = UNUserNotificationCenter.currentNotificationCenter()
         self.nc_delegate = NotificationCenterDelegate.alloc().init()
         self.nc_delegate.interface = self

--- a/src/desktop_notifier/macos_legacy.py
+++ b/src/desktop_notifier/macos_legacy.py
@@ -80,8 +80,6 @@ class CocoaNotificationCenterLegacy(DesktopNotifierBase):
 
     :param app_name: The name of the app. Does not have any effect because the app
         name is automatically determined from the bundle or framework.
-    :param app_icon: The icon of the app. Does not have any effect because the app
-        icon is automatically determined from the bundle or framework.
     :param notification_limit: Maximum number of notifications to keep in the system's
         notification center.
     """
@@ -89,10 +87,9 @@ class CocoaNotificationCenterLegacy(DesktopNotifierBase):
     def __init__(
         self,
         app_name: str = "Python",
-        app_icon: Optional[str] = None,
         notification_limit: Optional[int] = None,
     ) -> None:
-        super().__init__(app_name, app_icon, notification_limit)
+        super().__init__(app_name, notification_limit)
 
         self.nc = NSUserNotificationCenter.defaultUserNotificationCenter
         self.nc_delegate = NotificationCenterDelegate.alloc().init()

--- a/src/desktop_notifier/main.py
+++ b/src/desktop_notifier/main.py
@@ -140,6 +140,8 @@ class DesktopNotifier:
         notification center. This may be ignored by some implementations.
     """
 
+    app_icon: Optional[str]
+
     def __init__(
         self,
         app_name: str = "Python",
@@ -149,10 +151,12 @@ class DesktopNotifier:
         impl_cls = get_implementation()
 
         if isinstance(app_icon, Path):
-            app_icon = app_icon.as_uri()
+            self.app_icon = app_icon.as_uri()
+        else:
+            self.app_icon = app_icon
 
         self._lock = RLock()
-        self._impl = impl_cls(app_name, app_icon, notification_limit)
+        self._impl = impl_cls(app_name, notification_limit)
         self._did_request_authorisation = False
 
         # Use our own event loop for the sync API so that we don't interfere with any
@@ -181,19 +185,6 @@ class DesktopNotifier:
     def app_name(self, value: str) -> None:
         """Setter: app_name"""
         self._impl.app_name = value
-
-    @property
-    def app_icon(self) -> Optional[str]:
-        """The application icon: a URI for a local file or an icon name."""
-        return self._impl.app_icon
-
-    @app_icon.setter
-    def app_icon(self, value: Union[Path, str, None]) -> None:
-        """Setter: app_icon"""
-        if isinstance(value, Path):
-            value = value.as_uri()
-
-        self._impl.app_icon = value
 
     async def request_authorisation(self) -> bool:
         """


### PR DESCRIPTION
This prevents hacky workarounds on Windows when we cannot auto-detect the app ID, for example when running from a Python interpreter. See for example #41.