### PR TITLE
Fix displaying default button on XFCE

### DIFF
--- a/src/desktop_notifier/dbus.py
+++ b/src/desktop_notifier/dbus.py
@@ -117,8 +117,17 @@ class DBusDesktopNotifier(DesktopNotifierBase):
         else:
             replaces_nid = 0
 
-        # Create list of actions with default and user-supplied.
-        actions = ["default", "default"]
+        # Create list of actions for a user interacting with the notification.
+        actions = []
+
+        if notification.on_clicked:
+            # The "default" action is typically invoked when clicking on the
+            # notification body itself, see
+            # https://specifications.freedesktop.org/notification-spec. There are some
+            # exceptions though, such as XFCE, where this will result in a separate
+            # button. If no label name is provided in XFCE, it will result in a default
+            # symbol being used. We therefore don't specify a label name.
+            actions = ["default", ""]
 
         for n, button in enumerate(notification.buttons):
             actions += [str(n), button.title]


### PR DESCRIPTION
Fixes #90 by:

1. Not providing a label for the default action. This will result in a symbolic default button being created in XFCE instead of a button with label "default". See https://gitlab.xfce.org/apps/xfce4-notifyd/-/commit/ff368fd57d085f1e841f4800bb2d7787e12c7cab.
2. Not providing a default action in the first place if not requested by the caller.

Not that XFCE does not support callbacks when a notification is clicked and there are no plans to support this: https://gitlab.xfce.org/apps/xfce4-notifyd/-/issues/2.