### PR TITLE
Allow user to choose a system sound on macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Currently supported platforms are:
 `desktop-notifier` aims to be a good citizen of the platforms which it supports. It
 therefore stays within the limits of the native platform APIs and does not try to work
 around limitations which are often deliberate UI choices. For example, on macOS  and
-iOS, it is not possible to change the app icon which is shown on notifications. There
+iOS, it is not possible to change the app icon which is shown on notifications. There 
 are possible workarounds - that would likely be rejected by an App Store review - and
 desktop-notifier deliberately stays away from those.
 
@@ -63,7 +63,7 @@ notifier = DesktopNotifier()
 
 async def main():
     n = await notifier.send(title="Hello world!", message="Sent from Python")
-
+    
     await asyncio.sleep(5)  # wait a bit before clearing notification
 
     await notifier.clear(n)  # removes the notification
@@ -72,7 +72,7 @@ async def main():
 asyncio.run(main())
 ```
 
-For convenience, there is also a synchronous method ``send_sync()`` to send
+For convenience, there is also a synchronous method ``send_sync()`` to send 
 notifications without manually starting an asyncio event loop:
 
 ```Python
@@ -110,7 +110,7 @@ async def main():
       on_dismissed=lambda: print("Notification dismissed"),
       sound=True,
   )
-
+  
 
 loop = asyncio.get_event_loop()
 loop.create_task(main())
@@ -170,7 +170,7 @@ Note that the installer from [python.org](https://python.org) provides a properl
 Python framework but **homebrew does not** (manually signing the executable installed
 by homebrew *should* work as well).
 
-If you freeze your code with PyInstaller or a similar packaging solution, you must sign
+If you freeze your code with PyInstaller or a similar packaging solution, you must sign 
 the resulting app bundle for notifications to work. An ad-hoc signature will be
 sufficient but signing with an Apple developer certificate is recommended for
 distribution and may be required on future releases of macOS.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Currently supported platforms are:
 `desktop-notifier` aims to be a good citizen of the platforms which it supports. It
 therefore stays within the limits of the native platform APIs and does not try to work
 around limitations which are often deliberate UI choices. For example, on macOS  and
-iOS, it is not possible to change the app icon which is shown on notifications. There 
+iOS, it is not possible to change the app icon which is shown on notifications. There
 are possible workarounds - that would likely be rejected by an App Store review - and
 desktop-notifier deliberately stays away from those.
 
@@ -63,7 +63,7 @@ notifier = DesktopNotifier()
 
 async def main():
     n = await notifier.send(title="Hello world!", message="Sent from Python")
-    
+
     await asyncio.sleep(5)  # wait a bit before clearing notification
 
     await notifier.clear(n)  # removes the notification
@@ -72,7 +72,7 @@ async def main():
 asyncio.run(main())
 ```
 
-For convenience, there is also a synchronous method ``send_sync()`` to send 
+For convenience, there is also a synchronous method ``send_sync()`` to send
 notifications without manually starting an asyncio event loop:
 
 ```Python
@@ -110,7 +110,7 @@ async def main():
       on_dismissed=lambda: print("Notification dismissed"),
       sound=True,
   )
-  
+
 
 loop = asyncio.get_event_loop()
 loop.create_task(main())
@@ -170,7 +170,7 @@ Note that the installer from [python.org](https://python.org) provides a properl
 Python framework but **homebrew does not** (manually signing the executable installed
 by homebrew *should* work as well).
 
-If you freeze your code with PyInstaller or a similar packaging solution, you must sign 
+If you freeze your code with PyInstaller or a similar packaging solution, you must sign
 the resulting app bundle for notifications to work. An ad-hoc signature will be
 sufficient but signing with an Apple developer certificate is recommended for
 distribution and may be required on future releases of macOS.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Currently supported platforms are:
 `desktop-notifier` aims to be a good citizen of the platforms which it supports. It
 therefore stays within the limits of the native platform APIs and does not try to work
 around limitations which are often deliberate UI choices. For example, on macOS  and
-iOS, it is not possible to change the app icon which is shown on notifications. There 
+iOS, it is not possible to change the app icon which is shown on notifications. There
 are possible workarounds - that would likely be rejected by an App Store review - and
 desktop-notifier deliberately stays away from those.
 
@@ -63,7 +63,7 @@ notifier = DesktopNotifier()
 
 async def main():
     n = await notifier.send(title="Hello world!", message="Sent from Python")
-    
+
     await asyncio.sleep(5)  # wait a bit before clearing notification
 
     await notifier.clear(n)  # removes the notification
@@ -72,7 +72,7 @@ async def main():
 asyncio.run(main())
 ```
 
-For convenience, there is also a synchronous method ``send_sync()`` to send 
+For convenience, there is also a synchronous method ``send_sync()`` to send
 notifications without manually starting an asyncio event loop:
 
 ```Python
@@ -87,7 +87,7 @@ the top of the page:
 
 ```Python
 import asyncio
-from desktop_notifier import DesktopNotifier, Urgency, Button, ReplyField
+from desktop_notifier import DesktopNotifier, Urgency, Button, ReplyField, DEFAULT_SOUND
 
 notifier = DesktopNotifier()
 
@@ -108,9 +108,9 @@ async def main():
       ),
       on_clicked=lambda: print("Notification clicked"),
       on_dismissed=lambda: print("Notification dismissed"),
-      sound=True,
+      sound_file=DEFAULT_SOUND,
   )
-  
+
 
 loop = asyncio.get_event_loop()
 loop.create_task(main())
@@ -170,7 +170,7 @@ Note that the installer from [python.org](https://python.org) provides a properl
 Python framework but **homebrew does not** (manually signing the executable installed
 by homebrew *should* work as well).
 
-If you freeze your code with PyInstaller or a similar packaging solution, you must sign 
+If you freeze your code with PyInstaller or a similar packaging solution, you must sign
 the resulting app bundle for notifications to work. An ad-hoc signature will be
 sufficient but signing with an Apple developer certificate is recommended for
 distribution and may be required on future releases of macOS.

--- a/docs/background/platform_support.rst
+++ b/docs/background/platform_support.rst
@@ -26,7 +26,7 @@ Please refer to the platform documentation for more detailed information:
    "reply_field", "An interactive reply field", "--", "✓", "✓"
    "on_clicked", "A callback to invoke on click", "✓ [#f3]_", "✓", "✓"
    "on_dismissed", "A callback to invoke on dismissal", "✓ [#f3]_", "✓", "✓"
-   "sound", "Play a default sound with the notification", "✓ [#f3]_", "✓", "✓"
+   "sound", "Play the named sound with the notification", "✓ [#f3]_ [#f6]_", "✓ [#f7]_", "✓ [#f6]_"
    "thread", "An identifier to group notifications together", "--", "✓", "✓"
    "attachment", "File attachment, e.g., an image", "✓ [#f5]_", "✓ [#f5]_", "✓ [#f5]_"
    "timeout", "Duration until notification auto-dismissal", "✓ [#f3]_", "--", "--"
@@ -37,6 +37,9 @@ Please refer to the platform documentation for more detailed information:
 .. [#f3] May be ignored by some notification servers, depending on the desktop environment.
 .. [#f4] Only a single button is supported by our implementation for macOS 10.13 and lower.
 .. [#f5] Limitations on file types exist for each platform.
+.. [#f6] Currently only supports playing a default sound.
+.. [#f7] On macOS you can specify the filename stem of any file in `/System/Library/Sounds`,
+         e.g. `'Tink'` or `'Submarine'`.
 
 Callbacks
 *********

--- a/docs/background/platform_support.rst
+++ b/docs/background/platform_support.rst
@@ -26,7 +26,7 @@ Please refer to the platform documentation for more detailed information:
    "reply_field", "An interactive reply field", "--", "✓", "✓"
    "on_clicked", "A callback to invoke on click", "✓ [#f3]_", "✓", "✓"
    "on_dismissed", "A callback to invoke on dismissal", "✓ [#f3]_", "✓", "✓"
-   "sound", "Play the named sound with the notification", "✓ [#f3]_ [#f6]_", "✓ [#f7]_", "✓ [#f6]_"
+   "sound_file", "Play the named sound with the notification", "✓ [#f3]_ [#f6]_", "✓ [#f7]_", "✓ [#f6]_"
    "thread", "An identifier to group notifications together", "--", "✓", "✓"
    "attachment", "File attachment, e.g., an image", "✓ [#f5]_", "✓ [#f5]_", "✓ [#f5]_"
    "timeout", "Duration until notification auto-dismissal", "✓ [#f3]_", "--", "--"

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -40,7 +40,7 @@ notification options, such as notification urgency, buttons, callbacks, etc:
 
 .. code-block:: python
 
-    from desktop_notifier import DesktopNotifier, Urgency, Button, ReplyField
+    from desktop_notifier import DesktopNotifier, Urgency, Button, ReplyField, DEFAULT_SOUND
 
     notifier = DesktopNotifier(
         app_name="Sample App",
@@ -65,7 +65,7 @@ notification options, such as notification urgency, buttons, callbacks, etc:
           ),
           on_clicked=lambda: print("Notification clicked"),
           on_dismissed=lambda: print("Notification dismissed"),
-          sound=True,
+          sound_file=DEFAULT_SOUND,
         )
 
     asyncio.run(main())

--- a/examples/eventloop.py
+++ b/examples/eventloop.py
@@ -1,7 +1,7 @@
 import asyncio
 import platform
 
-from desktop_notifier import DesktopNotifier, Urgency, Button, ReplyField
+from desktop_notifier import DesktopNotifier, Urgency, Button, ReplyField, DEFAULT_SOUND
 
 
 notify = DesktopNotifier(
@@ -29,7 +29,7 @@ async def main() -> None:
         ),
         on_clicked=lambda: print("Notification clicked"),
         on_dismissed=lambda: print("Notification dismissed"),
-        sound=True,
+        sound_file=DEFAULT_SOUND,
     )
 
 

--- a/examples/synchronous.py
+++ b/examples/synchronous.py
@@ -1,4 +1,4 @@
-from desktop_notifier import DesktopNotifier, Urgency, Button, ReplyField
+from desktop_notifier import DesktopNotifier, Urgency, Button, ReplyField, DEFAULT_SOUND
 
 
 notify = DesktopNotifier(
@@ -24,5 +24,5 @@ notify.send_sync(
     ),
     on_clicked=lambda: print("Notification clicked"),
     on_dismissed=lambda: print("Notification dismissed"),
-    sound=True,
+    sound_file=DEFAULT_SOUND,
 )

--- a/src/desktop_notifier/__init__.py
+++ b/src/desktop_notifier/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from .main import DesktopNotifier, Button, ReplyField, Notification, Urgency
+from .main import DesktopNotifier, Button, ReplyField, Notification, Urgency, DEFAULT_SOUND
 
 
 __version__ = "4.0.0"
@@ -15,4 +15,5 @@ __all__ = [
     "ReplyField",
     "Urgency",
     "DesktopNotifier",
+    "DEFAULT_SOUND",
 ]

--- a/src/desktop_notifier/__init__.py
+++ b/src/desktop_notifier/__init__.py
@@ -1,5 +1,12 @@
 # -*- coding: utf-8 -*-
-from .main import DesktopNotifier, Button, ReplyField, Notification, Urgency, DEFAULT_SOUND
+from .main import (
+    DesktopNotifier,
+    Button,
+    ReplyField,
+    Notification,
+    Urgency,
+    DEFAULT_SOUND,
+)
 
 
 __version__ = "4.0.0"

--- a/src/desktop_notifier/base.py
+++ b/src/desktop_notifier/base.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 # system imports
 import logging
+import platform
 from enum import Enum
 from collections import deque
 from pathlib import Path
@@ -117,7 +118,8 @@ class Notification:
         callback will be called without any arguments.
     :attachment: URI for an attachment to the notification.
     :param sound: Whether to play a sound when the notification is shown or (optionally on macOS)
-        the name of the sound to play.
+        a string specifying the name of the sound to play chosen from the files in
+        /System/Library/Sounds (e.g. 'Tink' or 'Submarine')
     :param thread: An identifier to group related notifications together.
     :param timeout: Duration for which the notification in shown.
     """
@@ -137,6 +139,10 @@ class Notification:
         thread: str | None = None,
         timeout: int = -1,
     ) -> None:
+        if isinstance(sound, str) and platform.system() != "Darwin":
+            logger.warning("Custom sounds are only supported on macOS.")
+            sound = True
+
         self._identifier = ""
         self._winrt_identifier = ""
         self._macos_identifier = ""

--- a/src/desktop_notifier/base.py
+++ b/src/desktop_notifier/base.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 # system imports
 import logging
-import platform
+import warnings
 from enum import Enum
 from collections import deque
 from pathlib import Path
@@ -34,6 +34,7 @@ except ImportError:
 
 logger = logging.getLogger(__name__)
 
+DEFAULT_SOUND = 'default'
 PYTHON_ICON_PATH = resource_path("desktop_notifier.resources", "python.png").__enter__()
 
 
@@ -117,9 +118,8 @@ class Notification:
     :param on_dismissed: Callback to call when the notification is dismissed. The
         callback will be called without any arguments.
     :attachment: URI for an attachment to the notification.
-    :param sound: Whether to play a sound when the notification is shown or (optionally on macOS)
-        a string specifying the name of the sound to play chosen from the files in
-        /System/Library/Sounds (e.g. 'Tink' or 'Submarine')
+    :param sound_file: String identifying the sound to play when the notification is
+        shown. Pass desktop_notifier.DEFAULT_SOUND to use the default sound.
     :param thread: An identifier to group related notifications together.
     :param timeout: Duration for which the notification in shown.
     """
@@ -135,14 +135,10 @@ class Notification:
         on_clicked: Callable[[], Any] | None = None,
         on_dismissed: Callable[[], Any] | None = None,
         attachment: str | None = None,
-        sound: bool | str = False,
+        sound_file: str | None = None,
         thread: str | None = None,
         timeout: int = -1,
     ) -> None:
-        if isinstance(sound, str) and platform.system() != "Darwin":
-            logger.warning("Custom sounds are only supported on macOS.")
-            sound = True
-
         self._identifier = ""
         self._winrt_identifier = ""
         self._macos_identifier = ""
@@ -157,7 +153,7 @@ class Notification:
         self.on_clicked = on_clicked
         self.on_dismissed = on_dismissed
         self.attachment = attachment
-        self.sound = sound
+        self.sound_file = sound_file
         self.thread = thread
         self.timeout = timeout
 

--- a/src/desktop_notifier/base.py
+++ b/src/desktop_notifier/base.py
@@ -34,7 +34,7 @@ except ImportError:
 
 logger = logging.getLogger(__name__)
 
-DEFAULT_SOUND = 'default'
+DEFAULT_SOUND = "default"
 PYTHON_ICON_PATH = resource_path("desktop_notifier.resources", "python.png").__enter__()
 
 
@@ -142,7 +142,10 @@ class Notification:
         sound_file: str | None = None,
     ) -> None:
         if sound is True:
-            warnings.warn("Use sound_file=DEFAULT_SOUND instead of sound=True.", DeprecationWarning)
+            warnings.warn(
+                "Use sound_file=DEFAULT_SOUND instead of sound=True.",
+                DeprecationWarning
+            )
             sound_file = DEFAULT_SOUND
 
         self._identifier = ""

--- a/src/desktop_notifier/base.py
+++ b/src/desktop_notifier/base.py
@@ -117,11 +117,12 @@ class Notification:
         callback will be called without any arguments.
     :param on_dismissed: Callback to call when the notification is dismissed. The
         callback will be called without any arguments.
-    :attachment: URI for an attachment to the notification.
-    :param sound_file: String identifying the sound to play when the notification is
-        shown. Pass desktop_notifier.DEFAULT_SOUND to use the default sound.
+    :param attachment: URI for an attachment to the notification.
+    :param sound: [DEPRECATED] Use sound_file=DEFAULT_SOUND instead.
     :param thread: An identifier to group related notifications together.
     :param timeout: Duration for which the notification in shown.
+    :param sound_file: String identifying the sound to play when the notification is
+        shown. Pass desktop_notifier.DEFAULT_SOUND to use the default sound.
     """
 
     def __init__(
@@ -135,10 +136,15 @@ class Notification:
         on_clicked: Callable[[], Any] | None = None,
         on_dismissed: Callable[[], Any] | None = None,
         attachment: str | None = None,
-        sound_file: str | None = None,
+        sound: bool = False,
         thread: str | None = None,
         timeout: int = -1,
+        sound_file: str | None = None,
     ) -> None:
+        if sound is True:
+            warnings.warn("Use sound_file=DEFAULT_SOUND instead of sound=True.", DeprecationWarning)
+            sound_file = DEFAULT_SOUND
+
         self._identifier = ""
         self._winrt_identifier = ""
         self._macos_identifier = ""

--- a/src/desktop_notifier/base.py
+++ b/src/desktop_notifier/base.py
@@ -116,7 +116,8 @@ class Notification:
     :param on_dismissed: Callback to call when the notification is dismissed. The
         callback will be called without any arguments.
     :attachment: URI for an attachment to the notification.
-    :param sound: Whether to play a sound when the notification is shown.
+    :param sound: Whether to play a sound when the notification is shown or (optionally on macOS)
+        the name of the sound to play.
     :param thread: An identifier to group related notifications together.
     :param timeout: Duration for which the notification in shown.
     """
@@ -132,7 +133,7 @@ class Notification:
         on_clicked: Callable[[], Any] | None = None,
         on_dismissed: Callable[[], Any] | None = None,
         attachment: str | None = None,
-        sound: bool = False,
+        sound: bool | str = False,
         thread: str | None = None,
         timeout: int = -1,
     ) -> None:

--- a/src/desktop_notifier/base.py
+++ b/src/desktop_notifier/base.py
@@ -144,7 +144,7 @@ class Notification:
         if sound is True:
             warnings.warn(
                 "Use sound_file=DEFAULT_SOUND instead of sound=True.",
-                DeprecationWarning
+                DeprecationWarning,
             )
             sound_file = DEFAULT_SOUND
 

--- a/src/desktop_notifier/dbus.py
+++ b/src/desktop_notifier/dbus.py
@@ -146,7 +146,7 @@ class DBusDesktopNotifier(DesktopNotifierBase):
 
         hints = {"urgency": self._to_native_urgency[notification.urgency]}
 
-        if notification.sound:
+        if notification.sound_file:
             hints["sound-name"] = Variant("s", "message-new-instant")
 
         if notification.attachment:

--- a/src/desktop_notifier/macos.py
+++ b/src/desktop_notifier/macos.py
@@ -234,6 +234,7 @@ class CocoaNotificationCenter(DesktopNotifierBase):
         :param notification: Notification to send.
         :param notification_to_replace: Notification to replace, if any.
         """
+        print(f"_send() called with notification with sound: {notification.sound}")
         if notification_to_replace:
             platform_nid = notification_to_replace.identifier
         else:
@@ -253,7 +254,10 @@ class CocoaNotificationCenter(DesktopNotifierBase):
             content.interruptionLevel = self._to_native_urgency[notification.urgency]
 
         if notification.sound:
-            content.sound = UNNotificationSound.defaultSound
+            if isinstance(notification.sound, str):
+                content.sound = UNNotificationSound.soundNamed(notification.sound)
+            else:
+                content.sound = UNNotificationSound.defaultSound
 
         if notification.attachment:
             path = unquote(urlparse(notification.attachment).path)

--- a/src/desktop_notifier/macos.py
+++ b/src/desktop_notifier/macos.py
@@ -234,7 +234,6 @@ class CocoaNotificationCenter(DesktopNotifierBase):
         :param notification: Notification to send.
         :param notification_to_replace: Notification to replace, if any.
         """
-        print(f"_send() called with notification with sound: {notification.sound}")
         if notification_to_replace:
             platform_nid = notification_to_replace.identifier
         else:

--- a/src/desktop_notifier/macos.py
+++ b/src/desktop_notifier/macos.py
@@ -24,7 +24,13 @@ from rubicon.objc import NSObject, ObjCClass, objc_method, py_from_ns
 from rubicon.objc.runtime import load_library, objc_id, objc_block
 
 # local imports
-from .base import Notification, DesktopNotifierBase, AuthorisationError, Urgency, DEFAULT_SOUND
+from .base import (
+    Notification,
+    DesktopNotifierBase,
+    AuthorisationError,
+    Urgency,
+    DEFAULT_SOUND,
+)
 from .macos_support import macos_version
 
 

--- a/src/desktop_notifier/macos.py
+++ b/src/desktop_notifier/macos.py
@@ -24,7 +24,7 @@ from rubicon.objc import NSObject, ObjCClass, objc_method, py_from_ns
 from rubicon.objc.runtime import load_library, objc_id, objc_block
 
 # local imports
-from .base import Notification, DesktopNotifierBase, AuthorisationError, Urgency
+from .base import Notification, DesktopNotifierBase, AuthorisationError, Urgency, DEFAULT_SOUND
 from .macos_support import macos_version
 
 
@@ -252,11 +252,11 @@ class CocoaNotificationCenter(DesktopNotifierBase):
         if macos_version >= Version("12.0"):
             content.interruptionLevel = self._to_native_urgency[notification.urgency]
 
-        if notification.sound:
-            if isinstance(notification.sound, str):
-                content.sound = UNNotificationSound.soundNamed(notification.sound)
-            else:
+        if notification.sound_file:
+            if notification.sound_file == DEFAULT_SOUND:
                 content.sound = UNNotificationSound.defaultSound
+            else:
+                content.sound = UNNotificationSound.soundNamed(notification.sound_file)
 
         if notification.attachment:
             path = unquote(urlparse(notification.attachment).path)

--- a/src/desktop_notifier/main.py
+++ b/src/desktop_notifier/main.py
@@ -289,7 +289,7 @@ class DesktopNotifier:
         if sound is True:
             warnings.warn(
                 "Use sound_file=DEFAULT_SOUND instead of sound=True.",
-                DeprecationWarning
+                DeprecationWarning,
             )
             sound_file = DEFAULT_SOUND
 

--- a/src/desktop_notifier/main.py
+++ b/src/desktop_notifier/main.py
@@ -224,7 +224,7 @@ class DesktopNotifier:
         on_clicked: Callable[[], Any] | None = None,
         on_dismissed: Callable[[], Any] | None = None,
         attachment: Path | str | None = None,
-        sound: bool = False,
+        sound: bool = False,  # Deprecated
         sound_file: str | None = None,
         thread: str | None = None,
         timeout: int = -1,

--- a/src/desktop_notifier/main.py
+++ b/src/desktop_notifier/main.py
@@ -11,6 +11,7 @@ import platform
 from threading import RLock
 import logging
 import asyncio
+import warnings
 from pathlib import Path
 from typing import (
     Type,
@@ -32,6 +33,7 @@ from .base import (
     ReplyField,
     Notification,
     DesktopNotifierBase,
+    DEFAULT_SOUND,
     PYTHON_ICON_PATH,
 )
 
@@ -222,7 +224,8 @@ class DesktopNotifier:
         on_clicked: Callable[[], Any] | None = None,
         on_dismissed: Callable[[], Any] | None = None,
         attachment: Path | str | None = None,
-        sound: bool | str = False,
+        sound: bool = False,
+        sound_file: str | None = None,
         thread: str | None = None,
         timeout: int = -1,
     ) -> Notification:
@@ -264,9 +267,8 @@ class DesktopNotifier:
             platforms and Linux notification servers support different types of
             attachments. Please consult the platform support section of the
             documentation.
-        :param sound: Whether to play a sound when the notification is shown. If set to
-            True the default sound will be used. On macOS the user can choose from any
-            system sound in the /System/Library/Sounds/ directory by name.
+        :param sound_file: String identifying the sound to play when the notification is
+            shown. Pass desktop_notifier.DEFAULT_SOUND to use the default sound.
         :param thread: An identifier to group related notifications together. This is
             ignored on Linux.
         :param timeout: The duration (in seconds) for which the notification is shown
@@ -283,6 +285,10 @@ class DesktopNotifier:
         if isinstance(attachment, Path):
             attachment = attachment.as_uri()
 
+        if sound is True:
+            warnings.warn("Use sound_file=DEFAULT_SOUND instead of sound=True.", DeprecationWarning)
+            sound_file = DEFAULT_SOUND
+
         notification = Notification(
             title,
             message,
@@ -293,7 +299,7 @@ class DesktopNotifier:
             on_clicked,
             on_dismissed,
             attachment,
-            sound,
+            sound_file,
             thread,
             timeout,
         )
@@ -311,7 +317,8 @@ class DesktopNotifier:
         on_clicked: Callable[[], Any] | None = None,
         on_dismissed: Callable[[], Any] | None = None,
         attachment: Path | str | None = None,
-        sound: bool | str = False,
+        sound: bool = False,
+        sound_file: str | None = None,
         thread: str | None = None,
         timeout: int = -1,
     ) -> Notification:
@@ -331,6 +338,7 @@ class DesktopNotifier:
             on_dismissed,
             attachment,
             sound,
+            sound_file,
             thread,
             timeout,
         )

--- a/src/desktop_notifier/main.py
+++ b/src/desktop_notifier/main.py
@@ -222,7 +222,7 @@ class DesktopNotifier:
         on_clicked: Callable[[], Any] | None = None,
         on_dismissed: Callable[[], Any] | None = None,
         attachment: Path | str | None = None,
-        sound: bool = False,
+        sound: bool | str = False,
         thread: str | None = None,
         timeout: int = -1,
     ) -> Notification:
@@ -264,8 +264,9 @@ class DesktopNotifier:
             platforms and Linux notification servers support different types of
             attachments. Please consult the platform support section of the
             documentation.
-        :param sound: Whether to play a sound when the notification is shown. The
-            platform's default sound will be used, where available.
+        :param sound: Whether to play a sound when the notification is shown. If set to
+            True the default sound will be used. On macOS the user can choose from any
+            system sound in the /System/Library/Sounds/ directory by name.
         :param thread: An identifier to group related notifications together. This is
             ignored on Linux.
         :param timeout: The duration (in seconds) for which the notification is shown
@@ -310,7 +311,7 @@ class DesktopNotifier:
         on_clicked: Callable[[], Any] | None = None,
         on_dismissed: Callable[[], Any] | None = None,
         attachment: Path | str | None = None,
-        sound: bool = False,
+        sound: bool | str = False,
         thread: str | None = None,
         timeout: int = -1,
     ) -> Notification:

--- a/src/desktop_notifier/main.py
+++ b/src/desktop_notifier/main.py
@@ -275,7 +275,7 @@ class DesktopNotifier:
             unless dismissed. Only supported on Linux. Default is ``-1`` which implies
             OS-specified.
         :param sound_file: String identifying the sound to play when the notification is
-            shown. Pass desktop_notifier.DEFAULT_SOUND to use the default sound.
+            shown. Pass desktop_notifier.DEFAULT_SOUND to use the system default sound.
 
         :returns: The scheduled notification instance.
         """

--- a/src/desktop_notifier/main.py
+++ b/src/desktop_notifier/main.py
@@ -340,9 +340,9 @@ class DesktopNotifier:
             on_dismissed,
             attachment,
             sound,
-            sound_file,
             thread,
             timeout,
+            sound_file,
         )
         return self._run_coro_sync(coro)
 

--- a/src/desktop_notifier/main.py
+++ b/src/desktop_notifier/main.py
@@ -225,9 +225,9 @@ class DesktopNotifier:
         on_dismissed: Callable[[], Any] | None = None,
         attachment: Path | str | None = None,
         sound: bool = False,  # Deprecated
-        sound_file: str | None = None,
         thread: str | None = None,
         timeout: int = -1,
+        sound_file: str | None = None,
     ) -> Notification:
         """
         Sends a desktop notification.
@@ -267,13 +267,14 @@ class DesktopNotifier:
             platforms and Linux notification servers support different types of
             attachments. Please consult the platform support section of the
             documentation.
-        :param sound_file: String identifying the sound to play when the notification is
-            shown. Pass desktop_notifier.DEFAULT_SOUND to use the default sound.
+        :param sound: [DEPRECATED] Use sound_file=DEFAULT_SOUND instead.
         :param thread: An identifier to group related notifications together. This is
             ignored on Linux.
         :param timeout: The duration (in seconds) for which the notification is shown
             unless dismissed. Only supported on Linux. Default is ``-1`` which implies
             OS-specified.
+        :param sound_file: String identifying the sound to play when the notification is
+            shown. Pass desktop_notifier.DEFAULT_SOUND to use the default sound.
 
         :returns: The scheduled notification instance.
         """
@@ -317,10 +318,10 @@ class DesktopNotifier:
         on_clicked: Callable[[], Any] | None = None,
         on_dismissed: Callable[[], Any] | None = None,
         attachment: Path | str | None = None,
-        sound: bool = False,
-        sound_file: str | None = None,
+        sound: bool = False,  # Deprecated
         thread: str | None = None,
         timeout: int = -1,
+        sound_file: str | None = None,
     ) -> Notification:
         """
         Synchronous call of :meth:`send`, for use without an asyncio event loop.

--- a/src/desktop_notifier/main.py
+++ b/src/desktop_notifier/main.py
@@ -300,9 +300,10 @@ class DesktopNotifier:
             on_clicked,
             on_dismissed,
             attachment,
-            sound_file,
+            sound,
             thread,
             timeout,
+            sound_file
         )
 
         return await self.send_notification(notification)

--- a/src/desktop_notifier/main.py
+++ b/src/desktop_notifier/main.py
@@ -287,7 +287,10 @@ class DesktopNotifier:
             attachment = attachment.as_uri()
 
         if sound is True:
-            warnings.warn("Use sound_file=DEFAULT_SOUND instead of sound=True.", DeprecationWarning)
+            warnings.warn(
+                "Use sound_file=DEFAULT_SOUND instead of sound=True.",
+                DeprecationWarning
+            )
             sound_file = DEFAULT_SOUND
 
         notification = Notification(
@@ -303,7 +306,7 @@ class DesktopNotifier:
             sound,
             thread,
             timeout,
-            sound_file
+            sound_file,
         )
 
         return await self.send_notification(notification)

--- a/src/desktop_notifier/main.py
+++ b/src/desktop_notifier/main.py
@@ -43,6 +43,7 @@ __all__ = [
     "ReplyField",
     "Urgency",
     "DesktopNotifier",
+    "DEFAULT_SOUND",
 ]
 
 logger = logging.getLogger(__name__)

--- a/src/desktop_notifier/winrt.py
+++ b/src/desktop_notifier/winrt.py
@@ -209,7 +209,7 @@ class WinRTDesktopNotifier(DesktopNotifierBase):
                 },
             )
 
-        if notification.sound:
+        if notification.sound_file:
             SubElement(
                 toast_xml, "audio", {"src": "ms-winsoundevent:Notification.Default"}
             )

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,7 +1,7 @@
 import sys
 import pytest
 
-from desktop_notifier import Urgency, Button, ReplyField
+from desktop_notifier import Urgency, Button, ReplyField, DEFAULT_SOUND
 
 
 @pytest.mark.asyncio
@@ -23,7 +23,7 @@ async def test_send(notifier):
         ),
         on_clicked=lambda: print("Notification clicked"),
         on_dismissed=lambda: print("Notification dismissed"),
-        sound=True,
+        sound_file=DEFAULT_SOUND,
         thread="test_notifications",
         timeout=5,
     )
@@ -49,7 +49,7 @@ def test_send_sync(notifier):
         ),
         on_clicked=lambda: print("Notification clicked"),
         on_dismissed=lambda: print("Notification dismissed"),
-        sound=True,
+        sound_file=DEFAULT_SOUND,
         thread="test_notifications",
         timeout=5,
     )


### PR DESCRIPTION
Allow the user to specify by name one of the sounds that live in `/System/Library/Sounds` on macOS.

Theoretically according to [the documentation](https://developer.apple.com/documentation/usernotifications/unnotificationsound/init(named:)?language=objc) this would also allow the user to pick their own custom sound by name as long as they had packaged their python into a signed and sandboxed macOS app but I haven't tested that functionality. System sounds work great though.

Feel free to close this PR if it's not a feature you want. Also happy to make any requested changes as far code or documentation or whatever.

----

These are the sounds available on macOS as of late. I'm pretty sure they've all been around for a decade or more at this point:

```
$ ls -l /System/Library/Sounds/

Basso.aiff
Blow.aiff
Bottle.aiff
Frog.aiff
Funk.aiff
Glass.aiff
Hero.aiff
Morse.aiff
Ping.aiff
Pop.aiff
Purr.aiff
Sosumi.aiff
Submarine.aiff
Tink.aiff
```

`Frog.aiff` is a personal favorite.