### PR TITLE
Uniform resource API

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ dependencies = [
     "winrt-windows.foundation;sys_platform=='win32'",
     "winrt-windows.foundation.collections;sys_platform=='win32'",
     "winrt-windows.foundation.interop;sys_platform=='win32'",
+    "winrt-windows.foundation.metadata;sys_platform=='win32'",
     "winrt-windows.ui.notifications;sys_platform=='win32'",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,6 @@ dependencies = [
     "winrt-windows.foundation;sys_platform=='win32'",
     "winrt-windows.foundation.collections;sys_platform=='win32'",
     "winrt-windows.foundation.interop;sys_platform=='win32'",
-    "winrt-windows.foundation.metadata;sys_platform=='win32'",
     "winrt-windows.ui.notifications;sys_platform=='win32'",
 ]
 

--- a/src/desktop_notifier/__init__.py
+++ b/src/desktop_notifier/__init__.py
@@ -6,7 +6,11 @@ from .main import (
     Notification,
     Urgency,
     Capability,
+    Icon,
+    Sound,
+    Attachment,
     DEFAULT_SOUND,
+    DEFAULT_ICON,
 )
 
 
@@ -22,7 +26,11 @@ __all__ = [
     "Button",
     "ReplyField",
     "Urgency",
+    "Icon",
+    "Sound",
+    "Attachment",
     "DesktopNotifier",
     "Capability",
     "DEFAULT_SOUND",
+    "DEFAULT_ICON",
 ]

--- a/src/desktop_notifier/dbus.py
+++ b/src/desktop_notifier/dbus.py
@@ -146,20 +146,30 @@ class DBusDesktopNotifier(DesktopNotifierBase):
 
         hints = {"urgency": self._to_native_urgency[notification.urgency]}
 
-        if notification.sound_file:
-            hints["sound-name"] = Variant("s", "message-new-instant")
+        if notification.sound:
+            if notification.sound.is_named():
+                hints["sound-name"] = Variant("s", "message-new-instant")
+            else:
+                hints["sound-file"] = Variant("s", notification.sound.as_uri())
 
         if notification.attachment:
-            hints["image-path"] = Variant("s", notification.attachment)
+            hints["image-path"] = Variant("s", notification.attachment.as_uri())
 
         timeout = notification.timeout * 1000 if notification.timeout != -1 else -1
+        if notification.icon:
+            if notification.icon.is_named():
+                icon = notification.icon.name
+            else:
+                icon = notification.icon.as_uri()
+        else:
+            icon = ""
 
         # dbus_next proxy APIs are generated at runtime. Silence the type checker but
         # raise an AttributeError if required.
         platform_nid = await self.interface.call_notify(  # type:ignore[attr-defined]
             self.app_name,
             replaces_nid,
-            notification.icon or "",
+            icon,
             notification.title,
             notification.message,
             actions,

--- a/src/desktop_notifier/winrt.py
+++ b/src/desktop_notifier/winrt.py
@@ -19,7 +19,6 @@ from typing import TypeVar
 # external imports
 import winreg
 from winrt.windows.foundation.interop import unbox
-from winrt.windows.foundation.metadata import ApiInformation
 from winrt.windows.ui.notifications import (
     ToastNotificationManager,
     ToastNotificationPriority,
@@ -328,9 +327,6 @@ class WinRTDesktopNotifier(DesktopNotifierBase):
             Capability.ATTACHMENT,
             Capability.SOUND,
             Capability.SOUND_NAME,
+            Capability.SOUND_FILE,
         }
-        if ApiInformation.IsApiContractPresent(
-            "Windows.Foundation.UniversalApiContract", 2
-        ):
-            capabilities.add(Capability.SOUND_FILE)
         return frozenset(capabilities)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -52,21 +52,61 @@ async def test_default_icon(notifier):
 
 @pytest.mark.asyncio
 async def test_icon_name(notifier):
-    notification = await notifier.send(
-        title="Julius Caesar", message="Et tu, Brute?", icon=Icon(name="blue")
+    await notifier.send(
+        title="Julius Caesar", message="Et tu, Brute?", icon=Icon(name="call-start")
     )
 
 
 @pytest.mark.asyncio
 async def test_icon_path(notifier):
-    notification = await notifier.send(
-        title="Julius Caesar", message="Et tu, Brute?", icon=Icon(path=Path("blue"))
+    await notifier.send(
+        title="Julius Caesar", message="Et tu, Brute?", icon=Icon(path=Path("/blue"))
     )
 
 
+@pytest.mark.asyncio
 async def test_icon_uri(notifier):
-    notification = await notifier.send(
+    await notifier.send(
         title="Julius Caesar", message="Et tu, Brute?", icon=Icon(uri="file:///blue")
+    )
+
+
+@pytest.mark.asyncio
+async def test_sound_name(notifier):
+    await notifier.send(
+        title="Julius Caesar", message="Et tu, Brute?", sound=Sound(name="Tink")
+    )
+
+
+@pytest.mark.asyncio
+async def test_sound_path(notifier):
+    await notifier.send(
+        title="Julius Caesar", message="Et tu, Brute?", sound=Sound(path=Path("/blue"))
+    )
+
+
+@pytest.mark.asyncio
+async def test_sound_uri(notifier):
+    await notifier.send(
+        title="Julius Caesar", message="Et tu, Brute?", sound=Sound(uri="file:///blue")
+    )
+
+
+@pytest.mark.asyncio
+async def test_attachment_path(notifier):
+    await notifier.send(
+        title="Julius Caesar",
+        message="Et tu, Brute?",
+        attachment=Attachment(path=Path("/blue")),
+    )
+
+
+@pytest.mark.asyncio
+async def test_attachment_uri(notifier):
+    await notifier.send(
+        title="Julius Caesar",
+        message="Et tu, Brute?",
+        attachment=Attachment(uri="file:///blue"),
     )
 
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,7 +1,17 @@
 import sys
 import pytest
 
-from desktop_notifier import Urgency, Button, ReplyField, DEFAULT_SOUND
+from pathlib import Path
+from desktop_notifier import (
+    Urgency,
+    Button,
+    Icon,
+    Sound,
+    Attachment,
+    ReplyField,
+    DEFAULT_SOUND,
+    DEFAULT_ICON,
+)
 
 
 @pytest.mark.asyncio
@@ -23,12 +33,41 @@ async def test_send(notifier):
         ),
         on_clicked=lambda: print("Notification clicked"),
         on_dismissed=lambda: print("Notification dismissed"),
-        sound_file=DEFAULT_SOUND,
+        sound=DEFAULT_SOUND,
         thread="test_notifications",
         timeout=5,
     )
     assert notification in notifier.current_notifications
     assert notification.identifier != ""
+
+
+@pytest.mark.asyncio
+async def test_default_icon(notifier):
+    notification = await notifier.send(
+        title="Julius Caesar",
+        message="Et tu, Brute?",
+    )
+    assert notification.icon == DEFAULT_ICON
+
+
+@pytest.mark.asyncio
+async def test_icon_name(notifier):
+    notification = await notifier.send(
+        title="Julius Caesar", message="Et tu, Brute?", icon=Icon(name="blue")
+    )
+
+
+@pytest.mark.asyncio
+async def test_icon_path(notifier):
+    notification = await notifier.send(
+        title="Julius Caesar", message="Et tu, Brute?", icon=Icon(path=Path("blue"))
+    )
+
+
+async def test_icon_uri(notifier):
+    notification = await notifier.send(
+        title="Julius Caesar", message="Et tu, Brute?", icon=Icon(uri="file:///blue")
+    )
 
 
 def test_send_sync(notifier):
@@ -49,7 +88,7 @@ def test_send_sync(notifier):
         ),
         on_clicked=lambda: print("Notification clicked"),
         on_dismissed=lambda: print("Notification dismissed"),
-        sound_file=DEFAULT_SOUND,
+        sound=DEFAULT_SOUND,
         thread="test_notifications",
         timeout=5,
     )
@@ -78,6 +117,7 @@ async def test_clear(notifier):
     assert n0 not in notifier.current_notifications
 
 
+@pytest.mark.asyncio
 async def test_clear_all(notifier):
     n0 = await notifier.send(
         title="Julius Caesar",


### PR DESCRIPTION
Notification backends typically accept resources such as an icon, sound and attachment in different formats. Most commonly:

* Icon: Can be a named "system icon" or a file
* Sound: Can be a named "system system" or a file
* Attachment: Can be a file

Where a file is accepted, formats can also vary.

* The [Freedesktop DBUS spec](https://specifications.freedesktop.org/notification-spec/notification-spec-latest.html) requires that files be specified as a file URIs.
* Windows requires sound files be given as [`ms-appx` URIs](https://learn.microsoft.com/en-us/windows/apps/design/shell/tiles-and-notifications/custom-audio-on-toasts#add-the-custom-audio) while attachments can have [http, file or ms-appx URIs](https://learn.microsoft.com/en-us/uwp/schemas/tiles/toastschema/element-image#attributes).
* macOS requires a [file URL to be provided for attachments](https://developer.apple.com/documentation/usernotifications/unnotificationattachment/init(identifier:url:options:)-83grx?language=objc) and does not support custom sounds.

This contrasts with Python where it local files are idiomatically represented by a `pathlib.Path` or `str`.

This PR provides a uniform ARI for such resources by introducing `Icon`, `Sound` and `Attachment` classes which can be initialized with a name, URI string, or Path. This makes backend implementations more robust because they don't need to guess if the passed string represents a "named" resource, a file system path or a URI, while maintaining flexibility for clients.

This PR also adds support for custom sounds on Windows and Linux.