### PR TITLE
Ubuntu 20.04 compatibility

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ macos-11, macos-latest, ubuntu-20.04, ubuntu-latest, windows-2019, windows-latest ]
+        os: [ macos-12, macos-latest, ubuntu-20.04, ubuntu-latest, windows-2019, windows-latest ]
         python-version: ["3.9", "3.12"]
         include:
         - pre-command: ""

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,13 +11,44 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ macos-latest, ubuntu-latest, windows-latest ]
+        os: [ macos-11, macos-latest, ubuntu-20.04, ubuntu-latest, windows-2019, windows-latest ]
         python-version: ["3.9", "3.12"]
         include:
         - pre-command: ""
           pytest-run-prefix: ""
 
         - os: "ubuntu-latest"
+          pre-command: |
+            sudo apt update -y
+            sudo apt install -y --no-install-recommends \
+              blackbox \
+              dbus-x11 \
+              dbus-user-session \
+              notification-daemon
+
+            mkdir -p /usr/share/dbus-1/services
+
+            echo '
+            [D-BUS Service]
+            Name=org.freedesktop.Notifications
+            Exec=/usr/lib/notification-daemon/notification-daemon
+            ' > /usr/share/dbus-1/services/org.freedesktop.Notifications.service
+
+            # Start Virtual X server
+            echo "Start X server..."
+            Xvfb :99 -screen 0 2048x1536x24 &
+            sleep 1
+
+            DISPLAY=:99 dbus-launch
+            DISPLAY=:99 systemctl --user daemon-reload
+
+            # Start Window manager
+            echo "Start window manager..."
+            DISPLAY=:99 blackbox &
+            sleep 1
+          pytest-run-prefix: "DISPLAY=:99"
+
+        - os: "ubuntu-20.04"
           pre-command: |
             sudo apt update -y
             sudo apt install -y --no-install-recommends \

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,8 @@
   referenced by a URI or path.
 * Expand attachment API to allow passing a URI or path.
 * Add a `capabilities()` API that returns which features are supported by a platform.
+* Compatibility with Ubuntu 20.04 and other older Dbus notification servers which do not
+  conform to the current API spec.
 
 ## Changed:
 

--- a/src/desktop_notifier/dummy.py
+++ b/src/desktop_notifier/dummy.py
@@ -5,6 +5,8 @@ Dummy backend for unsupported platforms
 
 from __future__ import annotations
 
+import uuid
+
 from . import Capability
 from .base import Notification, DesktopNotifierBase
 
@@ -38,7 +40,7 @@ class DummyNotificationCenter(DesktopNotifierBase):
         notification: Notification,
         notification_to_replace: Notification | None,
     ) -> None:
-        pass
+        notification.identifier = str(uuid.uuid4())
 
     async def _clear(self, notification: Notification) -> None:
         pass


### PR DESCRIPTION
Support old DBUS notifications servers which do not conform to the current spec and expect hints in form of `dict[str, str]` instead of `dict[str, Variant]`.

This RP also adds older platforms (Ubuntu 20.04 and macOS 12) to the test matrix.

Fixes #143.