### PR TITLE
Add .venv to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ parts/
 sdist/
 var/
 venv/
+.venv/
 *.egg-info/
 *.dist-info/
 .installed.cfg

--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,8 @@ venv/
 # IntelliJ Idea family of suites
 .idea
 *.iml
+# VSCode config
+.vscode/
 ## File-based project format:
 *.ipr
 *.iws


### PR DESCRIPTION
I use `.venv/` usually as do at least a goodly number of other people.