### PR TITLE
Centralize logging config, allow package user to configure their own logging

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -4,6 +4,11 @@ import os
 import sys
 import time
 
+from desktop_notifier import (
+    __DESKTOP_NOTIFIER_PACKAGE_NAME__,
+    __version__
+)
+
 # -- Path setup ------------------------------------------------------------------------
 
 sys.path.insert(0, os.path.abspath("../src"))
@@ -11,9 +16,9 @@ sys.path.insert(0, os.path.abspath("../src"))
 # -- Project information ---------------------------------------------------------------
 
 author = "Sam Schott"
-version = "5.0.0"
+version = __version__
 release = version
-project = "desktop-notifier"
+project = __DESKTOP_NOTIFIER_PACKAGE_NAME__
 title = "Desktop-Notifier Documentation"
 copyright = "{}, {}".format(time.localtime().tm_year, author)
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -6,6 +6,7 @@ import time
 
 from desktop_notifier import (
     __DESKTOP_NOTIFIER_PACKAGE_NAME__,
+    __author__,
     __version__
 )
 
@@ -15,7 +16,7 @@ sys.path.insert(0, os.path.abspath("../src"))
 
 # -- Project information ---------------------------------------------------------------
 
-author = "Sam Schott"
+author = __author__
 version = __version__
 release = version
 project = __DESKTOP_NOTIFIER_PACKAGE_NAME__

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3 :: Only",
 ]
 requires-python = ">=3.7"

--- a/src/desktop_notifier/__init__.py
+++ b/src/desktop_notifier/__init__.py
@@ -17,13 +17,12 @@ from .main import (
     DEFAULT_SOUND,
     DEFAULT_ICON,
 )
-from .util.pkg_metadata_helper import (
+from .sync import DesktopNotifierSync
+from desktop_notifier.util.pkg_metadata_helper import (
     __DESKTOP_NOTIFIER_PACKAGE_NAME__,
     _get_primary_author_name,
     _get_project_url,
 )
-from .sync import DesktopNotifierSync
-
 
 __version__ = version(__DESKTOP_NOTIFIER_PACKAGE_NAME__)
 __author__ = _get_primary_author_name()

--- a/src/desktop_notifier/__init__.py
+++ b/src/desktop_notifier/__init__.py
@@ -2,8 +2,7 @@
 """
 Desktop notifications for Windows, Linux, macOS, iOS and iPadOS.
 """
-from email import parser, policy
-from importlib.metadata import metadata, version
+from importlib.metadata import version
 
 from .main import (
     DesktopNotifier,
@@ -18,39 +17,12 @@ from .main import (
     DEFAULT_SOUND,
     DEFAULT_ICON,
 )
+from .util.pkg_metadata_helper import (
+    __DESKTOP_NOTIFIER_PACKAGE_NAME__,
+    _get_primary_author_name,
+    _get_project_url
+)
 from .sync import DesktopNotifierSync
-
-__DESKTOP_NOTIFIER_PACKAGE_NAME__ = "desktop-notifier"
-__desktop_notifier_metadata = metadata(__DESKTOP_NOTIFIER_PACKAGE_NAME__)
-
-
-
-def _get_project_url() -> str | None:
-    """Parse project URLs from pyproject.toml package metadata."""
-    project_urls = __desktop_notifier_metadata.get('Project-URL')
-
-    if not project_urls is None:
-        return None
-
-    # 'project_urls' should be a string that looks like this
-    #    "Homepage, https://github.com/samschott/desktop-notifier"
-    if isinstance(project_urls, str):
-        return project_urls.split(',', maxsplit=1)[1].strip()
-
-
-# Using the approach in https://stackoverflow.com/questions/75801738/importlib-metadata-doesnt-appear-to-handle-the-authors-field-from-a-pyproject-t
-def _get_primary_author_name() -> str:
-    """Parse author name from pyproject.toml package metadata."""
-    email_parser = parser.Parser(policy=policy.default)
-    dummy_email_str = f"To: {__desktop_notifier_metadata.get('Author-email')}"
-    dummy_email = email_parser.parsestr(dummy_email_str)
-
-    try:
-        return dummy_email['to'].addresses[0].display_name
-    except IndexError:
-        print(f"WARNING: Could not parse author name from {dummy_email_str}")
-        return "Sam Schott"
-
 
 
 __version__ = version(__DESKTOP_NOTIFIER_PACKAGE_NAME__)

--- a/src/desktop_notifier/__init__.py
+++ b/src/desktop_notifier/__init__.py
@@ -20,7 +20,7 @@ from .main import (
 from .util.pkg_metadata_helper import (
     __DESKTOP_NOTIFIER_PACKAGE_NAME__,
     _get_primary_author_name,
-    _get_project_url
+    _get_project_url,
 )
 from .sync import DesktopNotifierSync
 
@@ -30,6 +30,7 @@ __author__ = _get_primary_author_name()
 __url__ = _get_project_url()
 
 __all__ = [
+    "__DESKTOP_NOTIFIER_PACKAGE_NAME__",
     "__version__",
     "__author__",
     "__url__",

--- a/src/desktop_notifier/__init__.py
+++ b/src/desktop_notifier/__init__.py
@@ -2,6 +2,9 @@
 """
 Desktop notifications for Windows, Linux, macOS, iOS and iPadOS.
 """
+from email import parser, policy
+from importlib.metadata import metadata, version
+
 from .main import (
     DesktopNotifier,
     Button,
@@ -17,9 +20,42 @@ from .main import (
 )
 from .sync import DesktopNotifierSync
 
-__version__ = "5.0.0"
-__author__ = "Sam Schott"
-__url__ = "https://github.com/samschott/desktop-notifier"
+__DESKTOP_NOTIFIER_PACKAGE_NAME__ = "desktop-notifier"
+__desktop_notifier_metadata = metadata(__DESKTOP_NOTIFIER_PACKAGE_NAME__)
+
+
+
+def _get_project_url() -> str | None:
+    """Parse project URLs from pyproject.toml package metadata."""
+    project_urls = __desktop_notifier_metadata.get('Project-URL')
+
+    if not project_urls is None:
+        return None
+
+    # 'project_urls' should be a string that looks like this
+    #    "Homepage, https://github.com/samschott/desktop-notifier"
+    if isinstance(project_urls, str):
+        return project_urls.split(',', maxsplit=1)[1].strip()
+
+
+# Using the approach in https://stackoverflow.com/questions/75801738/importlib-metadata-doesnt-appear-to-handle-the-authors-field-from-a-pyproject-t
+def _get_primary_author_name() -> str:
+    """Parse author name from pyproject.toml package metadata."""
+    email_parser = parser.Parser(policy=policy.default)
+    dummy_email_str = f"To: {__desktop_notifier_metadata.get('Author-email')}"
+    dummy_email = email_parser.parsestr(dummy_email_str)
+
+    try:
+        return dummy_email['to'].addresses[0].display_name
+    except IndexError:
+        print(f"WARNING: Could not parse author name from {dummy_email_str}")
+        return "Sam Schott"
+
+
+
+__version__ = version(__DESKTOP_NOTIFIER_PACKAGE_NAME__)
+__author__ = _get_primary_author_name()
+__url__ = _get_project_url()
 
 __all__ = [
     "__version__",

--- a/src/desktop_notifier/base.py
+++ b/src/desktop_notifier/base.py
@@ -6,7 +6,6 @@ must inherit from :class:`DesktopNotifierBase`.
 
 from __future__ import annotations
 
-import logging
 from urllib.parse import urlparse, unquote
 import urllib.parse
 import warnings
@@ -26,6 +25,8 @@ from typing import (
     ContextManager,
 )
 
+from desktop_notifier.util.logger import Logger
+
 __all__ = [
     "Capability",
     "FileResource",
@@ -43,6 +44,7 @@ __all__ = [
     "DEFAULT_SOUND",
 ]
 
+
 try:
     from importlib.resources import as_file, files
 
@@ -52,8 +54,6 @@ try:
 except ImportError:
     from importlib.resources import path as resource_path
 
-
-logger = logging.getLogger(__name__)
 
 python_icon_path = resource_path(
     package="desktop_notifier.resources", resource="python.png"
@@ -442,7 +442,7 @@ class DesktopNotifierBase(ABC):
             # a warning.
             if notification_to_replace:
                 self._current_notifications.appendleft(notification_to_replace)
-            logger.warning("Notification failed", exc_info=True)
+            Logger.logger().warning("Notification failed", exc_info=True)
         else:
             self._current_notifications.append(notification)
             self._notification_for_nid[notification.identifier] = notification

--- a/src/desktop_notifier/base.py
+++ b/src/desktop_notifier/base.py
@@ -6,10 +6,9 @@ must inherit from :class:`DesktopNotifierBase`.
 
 from __future__ import annotations
 
-from urllib.parse import urlparse, unquote
+import dataclasses
 import urllib.parse
 import warnings
-import dataclasses
 from dataclasses import dataclass
 from abc import ABC, abstractmethod
 from enum import Enum, auto
@@ -24,6 +23,7 @@ from typing import (
     Sequence,
     ContextManager,
 )
+from urllib.parse import unquote
 
 from desktop_notifier.util.logger import Logger
 
@@ -102,7 +102,7 @@ class FileResource:
         if self.path is not None:
             return self.path
         if self.uri is not None:
-            parsed_uri = urlparse(self.uri)
+            parsed_uri = urllib.parse.urlparse(self.uri)
             return Path(unquote(parsed_uri.path))
 
         raise AttributeError("No path or URI provided")

--- a/src/desktop_notifier/dbus.py
+++ b/src/desktop_notifier/dbus.py
@@ -19,11 +19,9 @@ from dbus_next.aio.proxy_object import ProxyInterface
 
 # local imports
 from .base import Notification, DesktopNotifierBase, Urgency, Capability
-
+from desktop_notifier.util.logger import Logger
 
 __all__ = ["DBusDesktopNotifier"]
-
-logger = logging.getLogger(__name__)
 
 T = TypeVar("T")
 
@@ -163,7 +161,7 @@ class DBusDesktopNotifier(DesktopNotifierBase):
         hints_signature = get_hints_signature(self.interface)
 
         if hints_signature == "":
-            logger.warning("Notification server not supported")
+            Logger.logger().warning("Notification server not supported")
             return
 
         hints: dict[str, str] | dict[str, Variant]

--- a/src/desktop_notifier/dbus.py
+++ b/src/desktop_notifier/dbus.py
@@ -9,7 +9,6 @@ interaction with a notification requires a running asyncio event loop.
 from __future__ import annotations
 
 # system imports
-import logging
 from typing import TypeVar
 
 # external imports

--- a/src/desktop_notifier/macos.py
+++ b/src/desktop_notifier/macos.py
@@ -12,7 +12,6 @@ UNUserNotificationCenter backend for macOS
 import shutil
 import tempfile
 import uuid
-import logging
 import enum
 import asyncio
 from pathlib import Path
@@ -33,11 +32,10 @@ from .base import (
     DEFAULT_SOUND,
 )
 from .macos_support import macos_version
+from desktop_notifier.util.logger import Logger
 
 
 __all__ = ["CocoaNotificationCenter"]
-
-logger = logging.getLogger(__name__)
 
 foundation = load_library("Foundation")
 uns = load_library("UserNotifications")
@@ -258,7 +256,7 @@ class CocoaNotificationCenter(DesktopNotifierBase):
                 tmp_path = Path(tmp_dir) / attachment_path.name
                 shutil.copy(attachment_path, tmp_path)
             except OSError:
-                logger.warning("Could not access attachment file", exc_info=True)
+                Logger.logger().warning("Could not access attachment file", exc_info=True)
             else:
                 url = NSURL.fileURLWithPath(str(tmp_path), isDirectory=False)
                 attachment = UNNotificationAttachment.attachmentWithIdentifier(
@@ -411,6 +409,6 @@ def log_nserror(error: NSError, prefix: str) -> None:  # type:ignore[valid-type]
     code = int(error.code)  # type:ignore[attr-defined]
     description = str(error.localizedDescription)  # type:ignore[attr-defined]
 
-    logger.warning(
+    Logger.logger().warning(
         "%s: domain=%s, code=%s, description=%s", prefix, domain, code, description
     )

--- a/src/desktop_notifier/macos.py
+++ b/src/desktop_notifier/macos.py
@@ -256,7 +256,10 @@ class CocoaNotificationCenter(DesktopNotifierBase):
                 tmp_path = Path(tmp_dir) / attachment_path.name
                 shutil.copy(attachment_path, tmp_path)
             except OSError:
-                Logger.logger().warning("Could not access attachment file", exc_info=True)
+                Logger.logger().warning(
+                    "Could not access attachment file",
+                    exc_info=True
+                )
             else:
                 url = NSURL.fileURLWithPath(str(tmp_path), isDirectory=False)
                 attachment = UNNotificationAttachment.attachmentWithIdentifier(

--- a/src/desktop_notifier/macos.py
+++ b/src/desktop_notifier/macos.py
@@ -257,8 +257,7 @@ class CocoaNotificationCenter(DesktopNotifierBase):
                 shutil.copy(attachment_path, tmp_path)
             except OSError:
                 Logger.logger().warning(
-                    "Could not access attachment file",
-                    exc_info=True
+                    "Could not access attachment file", exc_info=True
                 )
             else:
                 url = NSURL.fileURLWithPath(str(tmp_path), isDirectory=False)

--- a/src/desktop_notifier/main.py
+++ b/src/desktop_notifier/main.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 
 # system imports
 import platform
-import logging
 import asyncio
 import warnings
 from urllib import parse
@@ -38,6 +37,7 @@ from .base import (
     DEFAULT_SOUND,
     DEFAULT_ICON,
 )
+from desktop_notifier.util.logger import Logger
 
 __all__ = [
     "Notification",
@@ -52,8 +52,6 @@ __all__ = [
     "DEFAULT_SOUND",
     "DEFAULT_ICON",
 ]
-
-logger = logging.getLogger(__name__)
 
 T = TypeVar("T")
 
@@ -77,17 +75,17 @@ def get_implementation_class() -> Type[DesktopNotifierBase]:
             from .macos import CocoaNotificationCenter
 
             if not is_signed_bundle():
-                logger.warning(
+                Logger.logger().warning(
                     "Could not very signature of app bundle, notifications may fail"
                 )
             return CocoaNotificationCenter
         else:
             if has_unusernotificationcenter:
-                logger.warning(
+                Logger.logger().warning(
                     "Notification Center can only be used from an app bundle"
                 )
             else:
-                logger.warning("Only macOS 10.14 and later are supported")
+                Logger.logger().warning("Only macOS 10.14 and later are supported")
 
             from .dummy import DummyNotificationCenter
 

--- a/src/desktop_notifier/util/logger.py
+++ b/src/desktop_notifier/util/logger.py
@@ -14,6 +14,7 @@ Then:
     Logger.logger().info("This will be logged using the logger named 'my_logger'")
 """
 import logging
+from typing import Optional
 
 from desktop_notifier.util.pkg_metadata_helper import __DESKTOP_NOTIFIER_PACKAGE_NAME__
 
@@ -21,7 +22,7 @@ DEFAULT_LOGGER = logging.getLogger(__DESKTOP_NOTIFIER_PACKAGE_NAME__)
 
 
 class Logger:
-    _logger: logging.Logger | None = None
+    _logger: Optional[logging.Logger] = None
 
     @classmethod
     def logger(cls) -> logging.Logger:

--- a/src/desktop_notifier/util/logger.py
+++ b/src/desktop_notifier/util/logger.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+"""
+Centralizes logging for desktop-notifier. Configure your own logging with:
+
+.. code-block:: python
+    import logging
+    from desktop_notifier.util.logger import Logger
+    Logger.set_logger("my_logger")
+
+Then:
+
+.. code-block:: python
+    from desktop_notifier.util.logger import Logger
+    Logger.logger().info("This will be logged using the logger named 'my_logger'")
+"""
+import logging
+
+from desktop_notifier.util.pkg_metadata_helper import __DESKTOP_NOTIFIER_PACKAGE_NAME__
+
+DEFAULT_LOGGER = logging.getLogger(__DESKTOP_NOTIFIER_PACKAGE_NAME__)
+
+
+class Logger:
+    _logger: logging.Logger | None = None
+
+    @classmethod
+    def logger(cls) -> logging.Logger:
+        """Returns the currently configured Logger instance."""
+        return cls._logger or DEFAULT_LOGGER
+
+    @classmethod
+    def set_logger(cls, logger: logging.Logger | str) -> None:
+        """Configure Logger instance to use in desktop-notifier logging."""
+        if isinstance(logger, str):
+            cls._logger = logging.getLogger(logger)
+        else:
+            cls._logger = logger

--- a/src/desktop_notifier/util/logger.py
+++ b/src/desktop_notifier/util/logger.py
@@ -14,7 +14,7 @@ Then:
     Logger.logger().info("This will be logged using the logger named 'my_logger'")
 """
 import logging
-from typing import Optional
+from typing import Optional, Union
 
 from desktop_notifier.util.pkg_metadata_helper import __DESKTOP_NOTIFIER_PACKAGE_NAME__
 
@@ -30,7 +30,7 @@ class Logger:
         return cls._logger or DEFAULT_LOGGER
 
     @classmethod
-    def set_logger(cls, logger: logging.Logger | str) -> None:
+    def set_logger(cls, logger: Union[logging.Logger, str]) -> None:
         """Configure Logger instance to use in desktop-notifier logging."""
         if isinstance(logger, str):
             cls._logger = logging.getLogger(logger)

--- a/src/desktop_notifier/util/pkg_metadata_helper.py
+++ b/src/desktop_notifier/util/pkg_metadata_helper.py
@@ -10,15 +10,14 @@ __desktop_notifier_metadata = metadata(__DESKTOP_NOTIFIER_PACKAGE_NAME__)
 
 def _get_project_url() -> str | None:
     """Parse project URLs from pyproject.toml package metadata."""
-    project_urls = __desktop_notifier_metadata.get('Project-URL')
-
-    if not project_urls is None:
-        return None
+    project_urls = __desktop_notifier_metadata.get("Project-URL")
 
     # 'project_urls' should be a string that looks like this
     #    "Homepage, https://github.com/samschott/desktop-notifier"
     if isinstance(project_urls, str):
         return project_urls.split(',', maxsplit=1)[1].strip()
+    else:
+        print(f"WARNING: Could not parse project URL from {project_urls}")
 
 
 # Using the approach in https://stackoverflow.com/questions/75801738/importlib-metadata-doesnt-appear-to-handle-the-authors-field-from-a-pyproject-t

--- a/src/desktop_notifier/util/pkg_metadata_helper.py
+++ b/src/desktop_notifier/util/pkg_metadata_helper.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+# Helper methods for parsing data out of the pyproject.toml configuration in a
+# hopefully future-proof way.
+from email import parser, policy
+from importlib.metadata import metadata
+
+__DESKTOP_NOTIFIER_PACKAGE_NAME__ = "desktop-notifier"
+__desktop_notifier_metadata = metadata(__DESKTOP_NOTIFIER_PACKAGE_NAME__)
+
+
+def _get_project_url() -> str | None:
+    """Parse project URLs from pyproject.toml package metadata."""
+    project_urls = __desktop_notifier_metadata.get('Project-URL')
+
+    if not project_urls is None:
+        return None
+
+    # 'project_urls' should be a string that looks like this
+    #    "Homepage, https://github.com/samschott/desktop-notifier"
+    if isinstance(project_urls, str):
+        return project_urls.split(',', maxsplit=1)[1].strip()
+
+
+# Using the approach in https://stackoverflow.com/questions/75801738/importlib-metadata-doesnt-appear-to-handle-the-authors-field-from-a-pyproject-t
+def _get_primary_author_name() -> str:
+    """Parse author name from pyproject.toml package metadata."""
+    email_parser = parser.Parser(policy=policy.default)
+    dummy_email_str = f"To: {__desktop_notifier_metadata.get('Author-email')}"
+    dummy_email = email_parser.parsestr(dummy_email_str)
+
+    try:
+        return dummy_email['to'].addresses[0].display_name
+    except IndexError:
+        print(f"WARNING: Could not parse author name from {dummy_email_str}")
+        return "Sam Schott"

--- a/src/desktop_notifier/util/pkg_metadata_helper.py
+++ b/src/desktop_notifier/util/pkg_metadata_helper.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
-# Helper methods for parsing data out of the pyproject.toml configuration in a
-# hopefully future-proof way.
+"""
+Helper methods for parsing data out of the pyproject.toml configuration in a
+hopefully future-proof way.
+"""
 from email import parser, policy
 from importlib.metadata import metadata
 

--- a/src/desktop_notifier/util/pkg_metadata_helper.py
+++ b/src/desktop_notifier/util/pkg_metadata_helper.py
@@ -21,6 +21,7 @@ def _get_project_url() -> Optional[str]:
         return project_urls.split(",", maxsplit=1)[1].strip()
     else:
         print(f"WARNING: Could not parse project URL from {project_urls}")
+        return None
 
 
 # Using the approach in https://stackoverflow.com/questions/75801738/importlib-metadata-doesnt-appear-to-handle-the-authors-field-from-a-pyproject-t
@@ -31,7 +32,7 @@ def _get_primary_author_name() -> str:
     dummy_email = email_parser.parsestr(dummy_email_str)
 
     try:
-        return dummy_email["to"].addresses[0].display_name
+        return str(dummy_email["to"].addresses[0].display_name)
     except IndexError:
         print(f"WARNING: Could not parse author name from {dummy_email_str}")
         return "Sam Schott"

--- a/src/desktop_notifier/util/pkg_metadata_helper.py
+++ b/src/desktop_notifier/util/pkg_metadata_helper.py
@@ -17,7 +17,7 @@ def _get_project_url() -> str | None:
     # 'project_urls' should be a string that looks like this
     #    "Homepage, https://github.com/samschott/desktop-notifier"
     if isinstance(project_urls, str):
-        return project_urls.split(',', maxsplit=1)[1].strip()
+        return project_urls.split(",", maxsplit=1)[1].strip()
     else:
         print(f"WARNING: Could not parse project URL from {project_urls}")
 
@@ -30,7 +30,7 @@ def _get_primary_author_name() -> str:
     dummy_email = email_parser.parsestr(dummy_email_str)
 
     try:
-        return dummy_email['to'].addresses[0].display_name
+        return dummy_email["to"].addresses[0].display_name
     except IndexError:
         print(f"WARNING: Could not parse author name from {dummy_email_str}")
         return "Sam Schott"

--- a/src/desktop_notifier/util/pkg_metadata_helper.py
+++ b/src/desktop_notifier/util/pkg_metadata_helper.py
@@ -5,12 +5,13 @@ hopefully future-proof way.
 """
 from email import parser, policy
 from importlib.metadata import metadata
+from typing import Optional
 
 __DESKTOP_NOTIFIER_PACKAGE_NAME__ = "desktop-notifier"
 __desktop_notifier_metadata = metadata(__DESKTOP_NOTIFIER_PACKAGE_NAME__)
 
 
-def _get_project_url() -> str | None:
+def _get_project_url() -> Optional[str]:
     """Parse project URLs from pyproject.toml package metadata."""
     project_urls = __desktop_notifier_metadata.get("Project-URL")
 

--- a/src/desktop_notifier/winrt.py
+++ b/src/desktop_notifier/winrt.py
@@ -36,11 +36,10 @@ from winrt.system import Object as WinRTObject
 
 # local imports
 from .base import Notification, DesktopNotifierBase, Urgency, Capability, DEFAULT_SOUND
+from desktop_notifier.util.logger import Logger
 
 
 __all__ = ["WinRTDesktopNotifier"]
-
-logger = logging.getLogger(__name__)
 
 T = TypeVar("T")
 
@@ -287,11 +286,11 @@ class WinRTDesktopNotifier(DesktopNotifierBase):
             sender: ToastNotification | None, failed_args: ToastFailedEventArgs | None
         ) -> None:
             if failed_args:
-                logger.warning(
+                Logger.logger().warning(
                     f"Notification failed (error code {failed_args.error_code.value})"
                 )
             else:
-                logger.warning("Notification failed (unknown error code)")
+                Logger.logger().warning("Notification failed (unknown error code)")
 
         native.add_activated(on_activated)
         native.add_dismissed(on_dismissed)

--- a/src/desktop_notifier/winrt.py
+++ b/src/desktop_notifier/winrt.py
@@ -13,9 +13,8 @@ from __future__ import annotations
 # system imports
 import sys
 import uuid
-import logging
-from xml.etree.ElementTree import Element, SubElement, tostring
 from typing import TypeVar
+from xml.etree.ElementTree import Element, SubElement, tostring
 
 # external imports
 import winreg


### PR DESCRIPTION
This is an initial pass at implementing something for https://github.com/samschott/desktop-notifier/issues/146. 

1. The biggest change is that there's now a `desktop_notifier.util.logger.Logger` class that centralizes all the calls to `logger.info()` etc. across the package so that even if someone using this library doesn't configure their own full blown `Logger` they can still setup `logging.Handler`s and `logging.Formatter`s uniformly across the package.
1. in my initial attempt at implementing this I was trying to get at the `pyproject.toml` metadata to get the package name so I could name the logger after it. that ultimately didn't work out _but_ I ended up refactoring some of the package metadata stuff just so things like the version number weren't copy/pasted into multiple locations that one might forget to update. These changes are in this PR but they are also isolated [on their own branch](https://github.com/samschott/desktop-notifier/compare/main...michelcrypt4d4mus:desktop-notifier:metadata_cleanup?expand=1) in case you want those changes sooner than you want to merge the logging configuration changes.
1. Other than the heredoc comment in `logger.py` I haven't update the documentation at all. Figured I'd wait to see if this approach is ok w/you before doing that (or maybe the heredoc is enough?)
1. I have instrumented the package with some additional logging [on yet another branch](https://github.com/samschott/desktop-notifier/compare/main...michelcrypt4d4mus:metadata_cleanup_logconfig__localchanges_morelogs?expand=1). some of these new log lines are more informative than others but i'd be happy to change them all to `DEBUG` level (so they can be easily suppressed) and add them to the project if you're interested

There's a lot to hate here (especially stylistically) so feel free to request whatever kinds of changes.

