### PR TITLE
Lazily instantiate asyncio event loop; use currently running asyncio event loop if there is one

### DIFF
--- a/src/desktop_notifier/sync.py
+++ b/src/desktop_notifier/sync.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 # system imports
 import asyncio
-from typing import Callable, Coroutine, Any, Sequence, TypeVar, List
+from typing import Any, Callable, Coroutine, List, Optional, Sequence, TypeVar
 
 # local imports
 from .main import DesktopNotifier
@@ -45,7 +45,7 @@ class DesktopNotifierSync:
         notification_limit: int | None = None,
     ) -> None:
         self._async_api = DesktopNotifier(app_name, app_icon, notification_limit)
-        self._event_loop = None
+        self._event_loop: Optional[asyncio.AbstractEventLoop] = None
 
     def _run_coro_sync(self, coro: Coroutine[None, None, T]) -> T:
         # Make sure to always use the same loop because async queues, future, etc. are

--- a/src/desktop_notifier/sync.py
+++ b/src/desktop_notifier/sync.py
@@ -3,6 +3,7 @@
 Synchronous desktop notification API
 """
 
+import logging
 from __future__ import annotations
 
 # system imports
@@ -25,6 +26,7 @@ from .base import (
 
 __all__ = ["DesktopNotifierSync"]
 
+logger = logging.getLogger(__name__)
 
 T = TypeVar("T")
 
@@ -141,9 +143,9 @@ class DesktopNotifierSync:
         if self._event_loop is None:
             try:
                 self._event_loop = asyncio.get_running_loop()
-                print("Found running event loop, using it.")
+                logger.debug("Found running event loop, using it.")
             except RuntimeError:
-                print("No running event loop found, creating a new one.")
+                logger.debug("No running event loop found, creating a new one.")
                 self._event_loop = asyncio.new_event_loop()
 
         return self._event_loop

--- a/src/desktop_notifier/sync.py
+++ b/src/desktop_notifier/sync.py
@@ -3,8 +3,8 @@
 Synchronous desktop notification API
 """
 
-import logging
 from __future__ import annotations
+import logging
 
 # system imports
 import asyncio

--- a/src/desktop_notifier/sync.py
+++ b/src/desktop_notifier/sync.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 
 # system imports
 import asyncio
-from time import sleep
 from typing import Callable, Coroutine, Any, Sequence, TypeVar, List
 
 # local imports
@@ -29,8 +28,6 @@ __all__ = ["DesktopNotifierSync"]
 
 T = TypeVar("T")
 
-SLEEP_INTERVAL_SECONDS = 0.1
-
 
 class DesktopNotifierSync:
     """
@@ -48,20 +45,14 @@ class DesktopNotifierSync:
         notification_limit: int | None = None,
     ) -> None:
         self._async_api = DesktopNotifier(app_name, app_icon, notification_limit)
-        self._loop = None
+        self._event_loop = None
 
     def _run_coro_sync(self, coro: Coroutine[None, None, T]) -> T:
         # Make sure to always use the same loop because async queues, future, etc. are
         # always bound to a loop.
         if self._get_event_loop().is_running():
-            task = self._get_event_loop().create_task(coro)
-            print(f"Created asyncio.Task in currently running event loop: {task}")
-
-            # Can't actually wait for the task to finish here. Something like
-            #    while not task.done():
-            #        sleep(SLEEP_INTERVAL_SECONDS)
-            # Never finishes because the event loop is never given control to run the task.
-            res = None
+            future = asyncio.run_coroutine_threadsafe(coro, self._get_event_loop())
+            res = future.result()
         else:
             res = self._get_event_loop().run_until_complete(coro)
 
@@ -79,7 +70,6 @@ class DesktopNotifierSync:
 
     def request_authorisation(self) -> bool:
         """See :meth:`desktop_notifier.main.DesktopNotifier.request_authorisation`"""
-        print(f"Requesting authorization...")
         coro = self._async_api.request_authorisation()
         return self._run_coro_sync(coro)
 
@@ -90,7 +80,6 @@ class DesktopNotifierSync:
 
     def send_notification(self, notification: Notification) -> Notification:
         """See :meth:`desktop_notifier.main.DesktopNotifier.send_notification`"""
-        print(f"Sending notification...")
         coro = self._async_api.send_notification(notification)
         return self._run_coro_sync(coro)
 
@@ -148,13 +137,13 @@ class DesktopNotifierSync:
         return self._run_coro_sync(coro)
 
     def _get_event_loop(self) -> asyncio.AbstractEventLoop:
-        """Returns the event loop used by the synchronous API"""
-        if self._loop is None:
+        """Return the event loop. Create a new one if none is running."""
+        if self._event_loop is None:
             try:
+                self._event_loop = asyncio.get_running_loop()
                 print("Found running event loop, using it.")
-                self._loop = asyncio.get_running_loop()
             except RuntimeError:
                 print("No running event loop found, creating a new one.")
-                self._loop = asyncio.new_event_loop()
+                self._event_loop = asyncio.new_event_loop()
 
-        return self._loop
+        return self._event_loop

--- a/src/desktop_notifier/sync.py
+++ b/src/desktop_notifier/sync.py
@@ -54,17 +54,14 @@ class DesktopNotifierSync:
         # Make sure to always use the same loop because async queues, future, etc. are
         # always bound to a loop.
         if self._get_event_loop().is_running():
-            #future = self._get_event_loop().create_future()
-            #self._get_event_loop().call_soon(coro, future, 'the result')
-            print(f"creating task...")
             task = self._get_event_loop().create_task(coro)
-            print(f"Created task...")
-            #future = asyncio.run_coroutine_threadsafe(coro, self._get_event_loop())
-            # while not task.done():
-            #     print(f"Waiting for task to complete...")
-            #     sleep(SLEEP_INTERVAL_SECONDS)
+            print(f"Created asyncio.Task in currently running event loop: {task}")
 
-            res = task.result()
+            # Can't actually wait for the task to finish here. Something like
+            #    while not task.done():
+            #        sleep(SLEEP_INTERVAL_SECONDS)
+            # Never finishes because the event loop is never given control to run the task.
+            res = None
         else:
             res = self._get_event_loop().run_until_complete(coro)
 


### PR DESCRIPTION
As it is currently stands instantiating `DesktopNotifierSync()` results in an attempt to create a new `asyncio` event loop. This is not ideal if 
1. `desktop-notifier` library is being used in a larger project that is trying to do its own event loop management
2. `DesktopNotifierSync` is eagerly instantiated when the application is launched (my app was instantiating `DesktopNotifierSync() at launch time as more or less a singleton)

## Changes

This PR contains a small change that:
1. **makes `DesktopNotifierSync`'s event loop instantiation lazy:** it only bothers to find or construct an event loop once `send()` or similar is called by the application
2. **attempts to use the currently executing event loop if there is one:** there are some issues with this though, see below.

Theoretically this change would allow someone to use `DesktopNotifierSync` in a context where some other piece of code has already launched an `asyncio` event loop. Of course that might be of limited utility (if the app is already running an event loop why would you use `DesktopNotifierSync` as opposed to just doing it all asynchronously?) but given that i can see a situation where someone using the lib might want to do it (for instance let's say the event loop management is done by some other library they are relying on, which is more or less my use case) but it is admittedly pretty marginal.

## Issues

Unfortunately in my particular context of a [Twisted](https://github.com/twisted/twisted) networking app the code in this PR doesn't actually work. It just hangs indefinitely waiting for `future.result()`. i'm pretty sure (though not 100% sure) that this is the fault of Twisted which is a 20 year old networking library that implemented asynchronicity in python literally decades before `asyncio` even existed and as a result [hates it when you try to do any thread management outside of its purview](https://docs.twisted.org/en/twisted-18.7.0/core/howto/threading.html) but i could just be making a mistake... either way I figured it might be worth opening this PR just because lazy instantiation of `DesktopNotifierSync._loop` could prevent an event loop collision should someone attempt to use `DesktopNotifierSync` in a situation _with_ a running event loop but _without_ a `twisted.reactor` trying to manage threading and everything else.

To get `DesktopNotifierSync.send()` to work in my particular context I had to switch to using `asyncio.create_task()` instead of `asyncio.run_coroutine_threadsafe()` and then just discard the result of the coroutine via `return None` ([branch comparison view for these changes](https://github.com/michelcrypt4d4mus/desktop-notifier/compare/asyncio_delay_loop_start...michelcrypt4d4mus:desktop-notifier:asyncio_delay_loop_start_use_running_loop?expand=1)).  That's obviously less than ideal but at least it proves that it can be done.

## UPDATE: Example
This short block of code shows how this works in a situation where the event loop is created outside of `desktop-notifier`:
```python
import asyncio
from desktop_notifier.sync import DesktopNotifierSync
from time import sleep


loop = asyncio.new_event_loop()
print("Created event loop, sleeping...")
sleep(1)
print("Triggering notification...")

notifier = DesktopNotifierSync()
notifier.send(title='Nasir Jones', message='The World is Yours')
print("Triggered notification, starting event loop!")
loop.run_forever()
```

though i haven't tested trying to use `DesktopNotifierSync` in a situation where the event loop has been _both_ created _and_ started via `loop.run_forever()` or similar.
 