### PR TITLE
DRY up the package metadata so everything derives from `pyproject.toml`

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -4,6 +4,11 @@ import os
 import sys
 import time
 
+from desktop_notifier import (
+    __DESKTOP_NOTIFIER_PACKAGE_NAME__,
+    __version__
+)
+
 # -- Path setup ------------------------------------------------------------------------
 
 sys.path.insert(0, os.path.abspath("../src"))
@@ -11,9 +16,9 @@ sys.path.insert(0, os.path.abspath("../src"))
 # -- Project information ---------------------------------------------------------------
 
 author = "Sam Schott"
-version = "5.0.0"
+version = __version__
 release = version
-project = "desktop-notifier"
+project = __DESKTOP_NOTIFIER_PACKAGE_NAME__
 title = "Desktop-Notifier Documentation"
 copyright = "{}, {}".format(time.localtime().tm_year, author)
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -6,6 +6,7 @@ import time
 
 from desktop_notifier import (
     __DESKTOP_NOTIFIER_PACKAGE_NAME__,
+    __author__,
     __version__
 )
 
@@ -15,7 +16,7 @@ sys.path.insert(0, os.path.abspath("../src"))
 
 # -- Project information ---------------------------------------------------------------
 
-author = "Sam Schott"
+author = __author__
 version = __version__
 release = version
 project = __DESKTOP_NOTIFIER_PACKAGE_NAME__

--- a/src/desktop_notifier/__init__.py
+++ b/src/desktop_notifier/__init__.py
@@ -2,8 +2,7 @@
 """
 Desktop notifications for Windows, Linux, macOS, iOS and iPadOS.
 """
-from email import parser, policy
-from importlib.metadata import metadata, version
+from importlib.metadata import version
 
 from .main import (
     DesktopNotifier,
@@ -18,39 +17,12 @@ from .main import (
     DEFAULT_SOUND,
     DEFAULT_ICON,
 )
+from .util.pkg_metadata_helper import (
+    __DESKTOP_NOTIFIER_PACKAGE_NAME__,
+    _get_primary_author_name,
+    _get_project_url
+)
 from .sync import DesktopNotifierSync
-
-__DESKTOP_NOTIFIER_PACKAGE_NAME__ = "desktop-notifier"
-__desktop_notifier_metadata = metadata(__DESKTOP_NOTIFIER_PACKAGE_NAME__)
-
-
-
-def _get_project_url() -> str | None:
-    """Parse project URLs from pyproject.toml package metadata."""
-    project_urls = __desktop_notifier_metadata.get('Project-URL')
-
-    if not project_urls is None:
-        return None
-
-    # 'project_urls' should be a string that looks like this
-    #    "Homepage, https://github.com/samschott/desktop-notifier"
-    if isinstance(project_urls, str):
-        return project_urls.split(',', maxsplit=1)[1].strip()
-
-
-# Using the approach in https://stackoverflow.com/questions/75801738/importlib-metadata-doesnt-appear-to-handle-the-authors-field-from-a-pyproject-t
-def _get_primary_author_name() -> str:
-    """Parse author name from pyproject.toml package metadata."""
-    email_parser = parser.Parser(policy=policy.default)
-    dummy_email_str = f"To: {__desktop_notifier_metadata.get('Author-email')}"
-    dummy_email = email_parser.parsestr(dummy_email_str)
-
-    try:
-        return dummy_email['to'].addresses[0].display_name
-    except IndexError:
-        print(f"WARNING: Could not parse author name from {dummy_email_str}")
-        return "Sam Schott"
-
 
 
 __version__ = version(__DESKTOP_NOTIFIER_PACKAGE_NAME__)

--- a/src/desktop_notifier/__init__.py
+++ b/src/desktop_notifier/__init__.py
@@ -20,7 +20,7 @@ from .main import (
 from .util.pkg_metadata_helper import (
     __DESKTOP_NOTIFIER_PACKAGE_NAME__,
     _get_primary_author_name,
-    _get_project_url
+    _get_project_url,
 )
 from .sync import DesktopNotifierSync
 
@@ -30,6 +30,7 @@ __author__ = _get_primary_author_name()
 __url__ = _get_project_url()
 
 __all__ = [
+    "__DESKTOP_NOTIFIER_PACKAGE_NAME__",
     "__version__",
     "__author__",
     "__url__",

--- a/src/desktop_notifier/__init__.py
+++ b/src/desktop_notifier/__init__.py
@@ -2,6 +2,9 @@
 """
 Desktop notifications for Windows, Linux, macOS, iOS and iPadOS.
 """
+from email import parser, policy
+from importlib.metadata import metadata, version
+
 from .main import (
     DesktopNotifier,
     Button,
@@ -17,9 +20,42 @@ from .main import (
 )
 from .sync import DesktopNotifierSync
 
-__version__ = "5.0.0"
-__author__ = "Sam Schott"
-__url__ = "https://github.com/samschott/desktop-notifier"
+__DESKTOP_NOTIFIER_PACKAGE_NAME__ = "desktop-notifier"
+__desktop_notifier_metadata = metadata(__DESKTOP_NOTIFIER_PACKAGE_NAME__)
+
+
+
+def _get_project_url() -> str | None:
+    """Parse project URLs from pyproject.toml package metadata."""
+    project_urls = __desktop_notifier_metadata.get('Project-URL')
+
+    if not project_urls is None:
+        return None
+
+    # 'project_urls' should be a string that looks like this
+    #    "Homepage, https://github.com/samschott/desktop-notifier"
+    if isinstance(project_urls, str):
+        return project_urls.split(',', maxsplit=1)[1].strip()
+
+
+# Using the approach in https://stackoverflow.com/questions/75801738/importlib-metadata-doesnt-appear-to-handle-the-authors-field-from-a-pyproject-t
+def _get_primary_author_name() -> str:
+    """Parse author name from pyproject.toml package metadata."""
+    email_parser = parser.Parser(policy=policy.default)
+    dummy_email_str = f"To: {__desktop_notifier_metadata.get('Author-email')}"
+    dummy_email = email_parser.parsestr(dummy_email_str)
+
+    try:
+        return dummy_email['to'].addresses[0].display_name
+    except IndexError:
+        print(f"WARNING: Could not parse author name from {dummy_email_str}")
+        return "Sam Schott"
+
+
+
+__version__ = version(__DESKTOP_NOTIFIER_PACKAGE_NAME__)
+__author__ = _get_primary_author_name()
+__url__ = _get_project_url()
 
 __all__ = [
     "__version__",

--- a/src/desktop_notifier/base.py
+++ b/src/desktop_notifier/base.py
@@ -6,11 +6,10 @@ must inherit from :class:`DesktopNotifierBase`.
 
 from __future__ import annotations
 
+import dataclasses
 import logging
-from urllib.parse import urlparse, unquote
 import urllib.parse
 import warnings
-import dataclasses
 from dataclasses import dataclass
 from abc import ABC, abstractmethod
 from enum import Enum, auto
@@ -25,6 +24,7 @@ from typing import (
     Sequence,
     ContextManager,
 )
+from urllib.parse import unquote
 
 __all__ = [
     "Capability",
@@ -102,7 +102,7 @@ class FileResource:
         if self.path is not None:
             return self.path
         if self.uri is not None:
-            parsed_uri = urlparse(self.uri)
+            parsed_uri = urllib.parse.urlparse(self.uri)
             return Path(unquote(parsed_uri.path))
 
         raise AttributeError("No path or URI provided")

--- a/src/desktop_notifier/util/pkg_metadata_helper.py
+++ b/src/desktop_notifier/util/pkg_metadata_helper.py
@@ -17,7 +17,7 @@ def _get_project_url() -> str | None:
     # 'project_urls' should be a string that looks like this
     #    "Homepage, https://github.com/samschott/desktop-notifier"
     if isinstance(project_urls, str):
-        return project_urls.split(',', maxsplit=1)[1].strip()
+        return project_urls.split(",", maxsplit=1)[1].strip()
     else:
         print(f"WARNING: Could not parse project URL from {project_urls}")
 
@@ -30,7 +30,7 @@ def _get_primary_author_name() -> str:
     dummy_email = email_parser.parsestr(dummy_email_str)
 
     try:
-        return dummy_email['to'].addresses[0].display_name
+        return str(dummy_email["to"].addresses[0].display_name)
     except IndexError:
         print(f"WARNING: Could not parse author name from {dummy_email_str}")
         return "Sam Schott"

--- a/src/desktop_notifier/util/pkg_metadata_helper.py
+++ b/src/desktop_notifier/util/pkg_metadata_helper.py
@@ -10,15 +10,14 @@ __desktop_notifier_metadata = metadata(__DESKTOP_NOTIFIER_PACKAGE_NAME__)
 
 def _get_project_url() -> str | None:
     """Parse project URLs from pyproject.toml package metadata."""
-    project_urls = __desktop_notifier_metadata.get('Project-URL')
-
-    if not project_urls is None:
-        return None
+    project_urls = __desktop_notifier_metadata.get("Project-URL")
 
     # 'project_urls' should be a string that looks like this
     #    "Homepage, https://github.com/samschott/desktop-notifier"
     if isinstance(project_urls, str):
         return project_urls.split(',', maxsplit=1)[1].strip()
+    else:
+        print(f"WARNING: Could not parse project URL from {project_urls}")
 
 
 # Using the approach in https://stackoverflow.com/questions/75801738/importlib-metadata-doesnt-appear-to-handle-the-authors-field-from-a-pyproject-t

--- a/src/desktop_notifier/util/pkg_metadata_helper.py
+++ b/src/desktop_notifier/util/pkg_metadata_helper.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+# Helper methods for parsing data out of the pyproject.toml configuration in a
+# hopefully future-proof way.
+from email import parser, policy
+from importlib.metadata import metadata
+
+__DESKTOP_NOTIFIER_PACKAGE_NAME__ = "desktop-notifier"
+__desktop_notifier_metadata = metadata(__DESKTOP_NOTIFIER_PACKAGE_NAME__)
+
+
+def _get_project_url() -> str | None:
+    """Parse project URLs from pyproject.toml package metadata."""
+    project_urls = __desktop_notifier_metadata.get('Project-URL')
+
+    if not project_urls is None:
+        return None
+
+    # 'project_urls' should be a string that looks like this
+    #    "Homepage, https://github.com/samschott/desktop-notifier"
+    if isinstance(project_urls, str):
+        return project_urls.split(',', maxsplit=1)[1].strip()
+
+
+# Using the approach in https://stackoverflow.com/questions/75801738/importlib-metadata-doesnt-appear-to-handle-the-authors-field-from-a-pyproject-t
+def _get_primary_author_name() -> str:
+    """Parse author name from pyproject.toml package metadata."""
+    email_parser = parser.Parser(policy=policy.default)
+    dummy_email_str = f"To: {__desktop_notifier_metadata.get('Author-email')}"
+    dummy_email = email_parser.parsestr(dummy_email_str)
+
+    try:
+        return dummy_email['to'].addresses[0].display_name
+    except IndexError:
+        print(f"WARNING: Could not parse author name from {dummy_email_str}")
+        return "Sam Schott"

--- a/src/desktop_notifier/util/pkg_metadata_helper.py
+++ b/src/desktop_notifier/util/pkg_metadata_helper.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
-# Helper methods for parsing data out of the pyproject.toml configuration in a
-# hopefully future-proof way.
+"""
+Helper methods for parsing data out of the pyproject.toml configuration in a
+hopefully future-proof way.
+"""
 from email import parser, policy
 from importlib.metadata import metadata
 


### PR DESCRIPTION
when i started wandering down The Dark Path that ended up as PR #149 i initially did some refactoring / DRYification of the package metadata so that as much as possible variables in the code etc. come from values in `pyproject.toml`. bc i happened to keep this as a separate branch i figured i'd submit the PR instead of just immediately deleting it because even an extremely marginal improvement is still an improvement.

feel free to close unmerged.