### PR TITLE
More informative macOS logging

### DIFF
--- a/src/desktop_notifier/base.py
+++ b/src/desktop_notifier/base.py
@@ -444,7 +444,7 @@ class DesktopNotifierBase(ABC):
                 self._current_notifications.appendleft(notification_to_replace)
             logger.warning("Notification failed", exc_info=True)
         else:
-            logger.debug(f"Notification sent: {notification}")
+            logger.debug("Notification sent: %s", notification)
             self._current_notifications.append(notification)
             self._notification_for_nid[notification.identifier] = notification
 

--- a/src/desktop_notifier/base.py
+++ b/src/desktop_notifier/base.py
@@ -444,6 +444,7 @@ class DesktopNotifierBase(ABC):
                 self._current_notifications.appendleft(notification_to_replace)
             logger.warning("Notification failed", exc_info=True)
         else:
+            logger.debug(f"Notification sent: {notification}")
             self._current_notifications.append(notification)
             self._notification_for_nid[notification.identifier] = notification
 

--- a/src/desktop_notifier/macos.py
+++ b/src/desktop_notifier/macos.py
@@ -168,6 +168,7 @@ class CocoaNotificationCenter(DesktopNotifierBase):
 
         :returns: Whether authorisation has been granted.
         """
+        logger.debug("Requesting notification authorisation")
         future: Future[tuple[bool, str]] = Future()
 
         def on_auth_completed(granted: bool, error: objc_id) -> None:

--- a/src/desktop_notifier/macos.py
+++ b/src/desktop_notifier/macos.py
@@ -328,7 +328,7 @@ class CocoaNotificationCenter(DesktopNotifierBase):
         # Register new category if necessary.
         if category_id not in category_ids:
             # Create action for each button.
-            logger.debug(f"Creating new notification category '{category_id}'")
+            logger.debug("Creating new notification category: '%s'", category_id)
             actions = []
 
             if notification.reply_field:

--- a/src/desktop_notifier/macos.py
+++ b/src/desktop_notifier/macos.py
@@ -168,7 +168,7 @@ class CocoaNotificationCenter(DesktopNotifierBase):
 
         :returns: Whether authorisation has been granted.
         """
-        logger.debug("Requesting notification authorisation")
+        logger.debug("Requesting notification authorisation...")
         future: Future[tuple[bool, str]] = Future()
 
         def on_auth_completed(granted: bool, error: objc_id) -> None:
@@ -238,7 +238,7 @@ class CocoaNotificationCenter(DesktopNotifierBase):
         category_id = await self._find_or_create_notification_category(notification)
 
         if category_id is not None:
-            logger.debug(f"Notification category_id: {category_id}")
+            logger.debug("Notification category_id: %s", category_id)
 
         # Create the native notification and notification request.
         content = UNMutableNotificationContent.alloc().init()

--- a/src/desktop_notifier/macos_support.py
+++ b/src/desktop_notifier/macos_support.py
@@ -43,7 +43,7 @@ def is_bundle() -> bool:
     :returns: Whether we are inside an app bundle.
     """
     main_bundle = NSBundle.mainBundle
-    logger.info(f"main_bundle.bundleURL: {main_bundle.bundleURL}")
+    logger.debug(f"main_bundle.bundleURL: {main_bundle.bundleURL}")
     return main_bundle.bundleIdentifier is not None
 
 

--- a/src/desktop_notifier/macos_support.py
+++ b/src/desktop_notifier/macos_support.py
@@ -82,5 +82,5 @@ def is_signed_bundle() -> bool:
         return False
 
 
-def _log_unsigned_warning(msg: str)  -> None:
+def _log_unsigned_warning(msg: str) -> None:
     logger.warning(f"Unsigned bundle ({msg})")

--- a/src/desktop_notifier/macos_support.py
+++ b/src/desktop_notifier/macos_support.py
@@ -73,14 +73,17 @@ def is_signed_bundle() -> bool:
         None,
     )
 
-    if cast(int, signed_status) == 0:
+    signed_status = cast(int, signed_status)
+
+    if signed_status == 0:
         return True
     else:
         _codesigning_warning("SecStaticCodeCheckValidity", signed_status)
         return False
 
 
-def _codesigning_warning(fxn_name: str, os_status: int) -> str:
+def _codesigning_warning(fxn_name: str, os_status: int) -> None:
+    """Log a warning about a failed code signing check."""
     logger.warning(
         f"Cannot verify app signature. {fxn_name}() failed with OSStatus: {os_status}"
     )

--- a/src/desktop_notifier/macos_support.py
+++ b/src/desktop_notifier/macos_support.py
@@ -44,7 +44,7 @@ def is_bundle() -> bool:
 
     :returns: Whether we are inside an app bundle.
     """
-    return _bundle_id() is not None
+    return NSBundle.mainBundle.bundleIdentifier is not None
 
 
 def is_signed_bundle() -> bool:
@@ -57,10 +57,9 @@ def is_signed_bundle() -> bool:
         return False
 
     # Check for valid code signature on bundle.
-    main_bundle = NSBundle.mainBundle
     static_code = ctypes.c_void_p(0)
     err = sec.SecStaticCodeCreateWithPath(
-        main_bundle.bundleURL, kSecCSDefaultFlags, ctypes.byref(static_code)
+        NSBundle.mainBundle.bundleURL, kSecCSDefaultFlags, ctypes.byref(static_code)
     )
 
     if err != 0:
@@ -82,19 +81,11 @@ def is_signed_bundle() -> bool:
         return False
 
 
-def _codesigning_warning(fxn_name: str, os_status: int) -> None:
+def _codesigning_warning(call: str, os_status: int) -> None:
     """Log a warning about a failed code signing check."""
     logger.warning(
-        f"Cannot verify signature of bundle {_bundle_id()}. "
-        f"{fxn_name}() failed with OSStatus: {os_status}"
+        "Cannot verify signature of bundle %s. %s call failed with OSStatus: %s",
+        NSBundle.mainBundle.bundleIdentifier,
+        call,
+        os_status,
     )
-
-
-def _bundle_id() -> str | None:
-    """
-    Get the bundle identifier of the current app bundle.
-
-    :returns: The bundle ID of the current app bundle.
-    """
-    main_bundle = NSBundle.mainBundle
-    return main_bundle.bundleIdentifier

--- a/src/desktop_notifier/main.py
+++ b/src/desktop_notifier/main.py
@@ -219,7 +219,7 @@ class DesktopNotifier:
         # Ask for authorisation if not already done. On some platforms, this will
         # trigger a system dialog to ask the user for permission.
         if not self._did_request_authorisation:
-            logger.debug(f"Requesting notification center authorisation for the first time")
+            logger.debug(f"Requesting notification authorisation for the first time")
             await self.request_authorisation()
         else:
             logger.debug(f"Notification center authorisation was already requested")

--- a/src/desktop_notifier/main.py
+++ b/src/desktop_notifier/main.py
@@ -219,7 +219,7 @@ class DesktopNotifier:
         # Ask for authorisation if not already done. On some platforms, this will
         # trigger a system dialog to ask the user for permission.
         if not self._did_request_authorisation:
-            logger.debug(f"Requesting notification authorisation for the first time")
+            logger.debug(f"Requesting notification authorisation for the 1st time")
             await self.request_authorisation()
         else:
             logger.debug(f"Notification center authorisation was already requested")

--- a/src/desktop_notifier/main.py
+++ b/src/desktop_notifier/main.py
@@ -219,10 +219,9 @@ class DesktopNotifier:
         # Ask for authorisation if not already done. On some platforms, this will
         # trigger a system dialog to ask the user for permission.
         if not self._did_request_authorisation:
-            logger.debug(f"Requesting notification authorisation for the 1st time")
             await self.request_authorisation()
         else:
-            logger.debug(f"Notification center authorisation was already requested")
+            logger.debug("Notification center authorisation was already requested")
 
         # We attempt to send the notification regardless of authorization.
         # The user may have changed settings in the meantime.

--- a/src/desktop_notifier/main.py
+++ b/src/desktop_notifier/main.py
@@ -219,7 +219,10 @@ class DesktopNotifier:
         # Ask for authorisation if not already done. On some platforms, this will
         # trigger a system dialog to ask the user for permission.
         if not self._did_request_authorisation:
+            logger.debug(f"Requesting notification center authorisation for the first time")
             await self.request_authorisation()
+        else:
+            logger.debug(f"Notification center authorisation was already requested")
 
         # We attempt to send the notification regardless of authorization.
         # The user may have changed settings in the meantime.


### PR DESCRIPTION
When I was trying to debug https://github.com/samschott/desktop-notifier/issues/136 I ended up adding a fair amount of debug logging to the macOS notifier that proved pretty helpful in at least helping me understand how far in the notification sending process my code was getting. This PR has those extra logging calls as well as a minor rename of `_create_category_for_notification()` to `_find_or_create_notification_category()` which is more descriptive of what the method actually does.

happy to reduce/remove some of these but some of them i think are pretty important for anyone trying to debug notifications failures.