### PR TITLE
[WIP] Add count_delivered_notifications() for macOS

### DIFF
--- a/src/desktop_notifier/macos.py
+++ b/src/desktop_notifier/macos.py
@@ -225,9 +225,9 @@ class CocoaNotificationCenter(DesktopNotifierBase):
             future.set_result(py_from_ns(notifications))
 
         self.nc.getDeliveredNotificationsWithCompletionHandler(handler)
-        notifications = await asyncio.wrap_future(future)
-        logger.debug("Delivered %d notifications", len(notifications))
-        return len(notifications)
+        notification_count = len(await asyncio.wrap_future(future))
+        logger.debug("Delivered %d notifications", notification_count)
+        return notification_count
 
 
     async def _send(

--- a/src/desktop_notifier/macos.py
+++ b/src/desktop_notifier/macos.py
@@ -229,7 +229,6 @@ class CocoaNotificationCenter(DesktopNotifierBase):
         logger.debug("Delivered %d notifications", notification_count)
         return notification_count
 
-
     async def _send(
         self,
         notification: Notification,

--- a/src/desktop_notifier/macos.py
+++ b/src/desktop_notifier/macos.py
@@ -21,7 +21,7 @@ from typing import cast, Optional
 
 # external imports
 from packaging.version import Version
-from rubicon.objc import NSObject, ObjCClass, objc_method, py_from_ns
+from rubicon.objc import NSArray, NSObject, ObjCClass, objc_method, py_from_ns
 from rubicon.objc.runtime import load_library, objc_id, objc_block
 
 # local imports
@@ -51,6 +51,7 @@ UNNotificationCategory = ObjCClass("UNNotificationCategory")
 UNNotificationSound = ObjCClass("UNNotificationSound")
 UNNotificationAttachment = ObjCClass("UNNotificationAttachment")
 UNNotificationSettings = ObjCClass("UNNotificationSettings")
+UNNotification = ObjCClass("UNNotification")
 
 NSURL = ObjCClass("NSURL")
 NSSet = ObjCClass("NSSet")
@@ -211,6 +212,25 @@ class CocoaNotificationCenter(DesktopNotifierBase):
         settings.autorelease()  # type:ignore[attr-defined]
 
         return authorized
+
+    async def count_delivered_notifications(self) -> int:
+        """
+        Count how many notifications have been delivered. Note that each installed version of
+        the app will have its own count.
+        """
+        # Actual functionality
+        logger.debug("Counting delivered notifications...")
+        future: Future[NSArray[UNNotification]] = Future()  # type:ignore[valid-type]
+
+        def handler(notifications: objc_id) -> None:
+            future.set_result(py_from_ns(notifications))
+
+        self.nc.getDeliveredNotificationsWithCompletionHandler(handler)
+        notifications = await asyncio.wrap_future(future)
+        logger.debug("Delivered %d notifications", len(notifications))
+        #notifications.autorelease()  # type:ignore[attr-defined]
+        return len(notifications)
+
 
     async def _send(
         self,

--- a/src/desktop_notifier/macos.py
+++ b/src/desktop_notifier/macos.py
@@ -218,7 +218,6 @@ class CocoaNotificationCenter(DesktopNotifierBase):
         Count how many notifications have been delivered. Note that each installed version of
         the app will have its own count.
         """
-        # Actual functionality
         logger.debug("Counting delivered notifications...")
         future: Future[NSArray[UNNotification]] = Future()  # type:ignore[valid-type]
 
@@ -228,7 +227,6 @@ class CocoaNotificationCenter(DesktopNotifierBase):
         self.nc.getDeliveredNotificationsWithCompletionHandler(handler)
         notifications = await asyncio.wrap_future(future)
         logger.debug("Delivered %d notifications", len(notifications))
-        #notifications.autorelease()  # type:ignore[attr-defined]
         return len(notifications)
 
 

--- a/src/desktop_notifier/main.py
+++ b/src/desktop_notifier/main.py
@@ -297,7 +297,7 @@ class DesktopNotifier:
 
     async def count_delivered_notifications(self) -> int:
         """
-        Returns the number of notifications currently displayed for this app.
+        Returns the number of notifications ever sent for this app.
         """
         from .macos import CocoaNotificationCenter
 

--- a/src/desktop_notifier/main.py
+++ b/src/desktop_notifier/main.py
@@ -294,3 +294,14 @@ class DesktopNotifier:
         if not self._capabilities:
             self._capabilities = await self._impl.get_capabilities()
         return self._capabilities
+
+    async def count_delivered_notifications(self) -> int:
+        """
+        Returns the number of notifications currently displayed for this app.
+        """
+        from .macos import CocoaNotificationCenter
+
+        if not isinstance(self._impl, CocoaNotificationCenter):
+            raise NotImplementedError(f"This method is only implemented for macOS")
+
+        return await self._impl.count_delivered_notifications()

--- a/src/desktop_notifier/main.py
+++ b/src/desktop_notifier/main.py
@@ -302,6 +302,6 @@ class DesktopNotifier:
         from .macos import CocoaNotificationCenter
 
         if not isinstance(self._impl, CocoaNotificationCenter):
-            raise NotImplementedError(f"This method is only implemented for macOS")
+            raise NotImplementedError("This method is only implemented for macOS")
 
         return await self._impl.count_delivered_notifications()

--- a/src/desktop_notifier/main.py
+++ b/src/desktop_notifier/main.py
@@ -12,6 +12,7 @@ import asyncio
 import warnings
 from urllib import parse
 from pathlib import Path
+from sys import version_info
 from typing import (
     Type,
     Callable,
@@ -300,8 +301,11 @@ class DesktopNotifier:
         Returns the number of notifications ever sent for this app.
         """
         from .macos import CocoaNotificationCenter
+        from .macos_support import macos_version
 
         if not isinstance(self._impl, CocoaNotificationCenter):
             raise NotImplementedError("This method is only implemented for macOS")
+        elif macos_version < Version("13.0") and version_info.minor < 10:
+            raise NotImplementedError("Requires python 3.10+ on macOS 12 or lower")
 
         return await self._impl.count_delivered_notifications()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,3 +1,4 @@
+import platform
 import sys
 import pytest
 
@@ -39,6 +40,17 @@ async def test_send(notifier):
     )
     assert notification in notifier.current_notifications
     assert notification.identifier != ""
+
+
+@pytest.mark.asyncio
+async def test_count_delivered_notifications(notifier):
+    if platform.system() != "Darwin":
+        return
+
+    old_count = await notifier.count_delivered_notifications()
+    await notifier.send(title="Julius Caesar", message="Et tu, Brute?")
+    new_count = await notifier.count_delivered_notifications()
+    assert (new_count - old_count) == 1
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
This is a utility function i had in my project that I figured might be worth moving into the library though I'm dubious as to whether this is the best way to go about it... I've almost never worked with the various python/objc bindings so there might be a better way.