### PR TITLE
switch from dbus-next to dbus-fast

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ requires-python = ">=3.7"
 dependencies = [
     "bidict",
     "packaging",
-    "dbus-next;sys_platform=='linux'",
+    "dbus-fast;sys_platform=='linux'",
     "rubicon-objc;sys_platform=='darwin'",
     "winrt-windows.applicationmodel.core;sys_platform=='win32'",
     "winrt-windows.data.xml.dom;sys_platform=='win32'",

--- a/src/desktop_notifier/backends/dbus.py
+++ b/src/desktop_notifier/backends/dbus.py
@@ -11,10 +11,10 @@ import logging
 from typing import TypeVar
 
 from bidict import bidict
-from dbus_next.aio.message_bus import MessageBus
-from dbus_next.aio.proxy_object import ProxyInterface
-from dbus_next.errors import DBusError
-from dbus_next.signature import Variant
+from dbus_fast.aio.message_bus import MessageBus
+from dbus_fast.aio.proxy_object import ProxyInterface
+from dbus_fast.errors import DBusError
+from dbus_fast.signature import Variant
 
 from ..common import Capability, Notification, Urgency
 from .base import DesktopNotifierBackend


### PR DESCRIPTION
`dbus-fast` is a still active drop-in replacement for the now abandoned `dbus-next`