### PR TITLE
Get real current notifications on macOS

### DIFF
--- a/tests/test_sync_api.py
+++ b/tests/test_sync_api.py
@@ -1,4 +1,5 @@
 import sys
+import time
 
 import pytest
 
@@ -9,6 +10,19 @@ from desktop_notifier import (
     ReplyField,
     Urgency,
 )
+
+
+def wait_for_notifications(
+    notifier: DesktopNotifierSync, notification_count: int = 1, timeout_sec: float = 2.0
+) -> None:
+    t0 = time.monotonic()
+
+    while time.monotonic() - t0 < timeout_sec:
+        if len(notifier.get_current_notifications()) == notification_count:
+            return
+        time.sleep(0.2)
+
+    raise TimeoutError("Timed out while waiting for notifications")
 
 
 def test_send(notifier_sync: DesktopNotifierSync) -> None:
@@ -33,6 +47,7 @@ def test_send(notifier_sync: DesktopNotifierSync) -> None:
         thread="test_notifications",
         timeout=5,
     )
+    wait_for_notifications(notifier_sync)
     assert notification in notifier_sync.get_current_notifications()
 
 
@@ -49,7 +64,9 @@ def test_clear(notifier_sync: DesktopNotifierSync) -> None:
         title="Julius Caesar",
         message="Et tu, Brute?",
     )
+    wait_for_notifications(notifier_sync, 2)
     current_notifications = notifier_sync.get_current_notifications()
+
     assert n0 in current_notifications
     assert n1 in current_notifications
 
@@ -66,8 +83,9 @@ def test_clear_all(notifier_sync: DesktopNotifierSync) -> None:
         title="Julius Caesar",
         message="Et tu, Brute?",
     )
-
+    wait_for_notifications(notifier_sync, 2)
     current_notifications = notifier_sync.get_current_notifications()
+
     assert n0 in current_notifications
     assert n1 in current_notifications
 


### PR DESCRIPTION
Instead of getting delivered notifications from our cache, get them directly from macOS APIs.