### PR TITLE
Move DesktopNotifier.app_icon to DesktopNotifierBackend.app_icon

### DIFF
--- a/src/desktop_notifier/backends/base.py
+++ b/src/desktop_notifier/backends/base.py
@@ -8,7 +8,7 @@ import logging
 from abc import ABC, abstractmethod
 from typing import Any, Callable
 
-from ..common import Capability, Notification
+from ..common import Capability, Icon, Notification
 
 __all__ = [
     "DesktopNotifierBackend",
@@ -24,8 +24,9 @@ class DesktopNotifierBackend(ABC):
     :param app_name: Name to identify the application in the notification center.
     """
 
-    def __init__(self, app_name: str) -> None:
+    def __init__(self, app_name: str, app_icon: Icon | None = None) -> None:
         self.app_name = app_name
+        self.app_icon = app_icon
         self._notification_cache: dict[str, Notification] = dict()
 
         self.on_clicked: Callable[[str], Any] | None = None

--- a/src/desktop_notifier/backends/dummy.py
+++ b/src/desktop_notifier/backends/dummy.py
@@ -11,9 +11,6 @@ from .base import DesktopNotifierBackend
 class DummyNotificationCenter(DesktopNotifierBackend):
     """A dummy backend for unsupported platforms"""
 
-    def __init__(self, app_name: str) -> None:
-        super().__init__(app_name)
-
     async def request_authorisation(self) -> bool:
         """
         Request authorisation to send notifications.

--- a/src/desktop_notifier/backends/macos.py
+++ b/src/desktop_notifier/backends/macos.py
@@ -22,7 +22,7 @@ from packaging.version import Version
 from rubicon.objc import NSObject, ObjCClass, objc_method, py_from_ns
 from rubicon.objc.runtime import load_library, objc_block, objc_id
 
-from ..common import DEFAULT_SOUND, Capability, Notification, Urgency
+from ..common import DEFAULT_SOUND, Capability, Icon, Notification, Urgency
 from .base import DesktopNotifierBackend
 from .macos_support import macos_version
 
@@ -129,8 +129,8 @@ class CocoaNotificationCenter(DesktopNotifierBackend):
         Urgency.Critical: UNNotificationInterruptionLevel.TimeSensitive,
     }
 
-    def __init__(self, app_name: str) -> None:
-        super().__init__(app_name)
+    def __init__(self, app_name: str, app_icon: Icon | None = None) -> None:
+        super().__init__(app_name, app_icon)
         self.nc = UNUserNotificationCenter.currentNotificationCenter()
         self.nc_delegate = NotificationCenterDelegate.alloc().init()
         self.nc_delegate.implementation = self

--- a/src/desktop_notifier/backends/winrt.py
+++ b/src/desktop_notifier/backends/winrt.py
@@ -31,7 +31,7 @@ from winrt.windows.ui.notifications import (
 )
 
 # local imports
-from ..common import DEFAULT_SOUND, Capability, Notification, Urgency
+from ..common import DEFAULT_SOUND, Capability, Icon, Notification, Urgency
 from .base import DesktopNotifierBackend
 
 __all__ = ["WinRTDesktopNotifier"]
@@ -69,11 +69,8 @@ class WinRTDesktopNotifier(DesktopNotifierBackend):
         Urgency.Critical: ToastNotificationPriority.HIGH,
     }
 
-    def __init__(
-        self,
-        app_name: str,
-    ) -> None:
-        super().__init__(app_name)
+    def __init__(self, app_name: str, app_icon: Icon | None = None) -> None:
+        super().__init__(app_name, app_icon)
 
         manager = ToastNotificationManager.get_default()
 
@@ -145,13 +142,18 @@ class WinRTDesktopNotifier(DesktopNotifierBackend):
         message_xml = SubElement(binding, "text")
         message_xml.text = notification.message
 
-        if notification.icon and notification.icon.is_file():
+        icon_obj: Icon | None = None
+        if notification.icon:
+            icon_obj = notification.icon
+        elif self.app_icon:
+            icon_obj = self.app_icon
+        if icon_obj and icon_obj.is_file():
             SubElement(
                 binding,
                 "image",
                 {
                     "placement": "appLogoOverride",
-                    "src": notification.icon.as_uri(),
+                    "src": icon_obj.as_uri(),
                 },
             )
 

--- a/src/desktop_notifier/common.py
+++ b/src/desktop_notifier/common.py
@@ -100,6 +100,11 @@ class Resource(FileResource):
     name: str | None = None
     """Name of the system resource"""
 
+    def as_name(self) -> str:
+        if self.name is not None:
+            return self.name
+        raise AttributeError("No resource name provided")
+
     def is_named(self) -> bool:
         """Returns whether the instance was initialized with ``name``"""
         return self.name is not None

--- a/src/desktop_notifier/main.py
+++ b/src/desktop_notifier/main.py
@@ -127,8 +127,6 @@ class DesktopNotifier:
         deprecated.
     """
 
-    app_icon: Icon | None
-
     def __init__(
         self,
         app_name: str = "Python",
@@ -141,10 +139,8 @@ class DesktopNotifier:
                 category=DeprecationWarning,
             )
 
-        self.app_icon = app_icon
-
         backend = get_backend_class()
-        self._backend = backend(app_name)
+        self._backend = backend(app_name, app_icon)
         self._did_request_authorisation = False
 
         self._capabilities: frozenset[Capability] | None = None
@@ -156,8 +152,16 @@ class DesktopNotifier:
 
     @app_name.setter
     def app_name(self, value: str) -> None:
-        """Setter: app_name"""
         self._backend.app_name = value
+
+    @property
+    def app_icon(self) -> Icon | None:
+        """The application icon"""
+        return self._backend.app_icon
+
+    @app_icon.setter
+    def app_icon(self, value: Icon | None) -> None:
+        self._backend.app_icon = value
 
     async def request_authorisation(self) -> bool:
         """
@@ -192,9 +196,6 @@ class DesktopNotifier:
         :param notification: The notification to send.
         :returns: An identifier for the scheduled notification.
         """
-        if not notification.icon:
-            object.__setattr__(notification, "icon", self.app_icon)
-
         # Ask for authorisation if not already done. On some platforms, this will
         # trigger a system dialog to ask the user for permission.
         if not self._did_request_authorisation:

--- a/src/desktop_notifier/sync.py
+++ b/src/desktop_notifier/sync.py
@@ -62,8 +62,16 @@ class DesktopNotifierSync:
 
     @app_name.setter
     def app_name(self, value: str) -> None:
-        """Setter: app_name"""
         self._async_api.app_name = value
+
+    @property
+    def app_icon(self) -> Icon | None:
+        """The application icon"""
+        return self._async_api.app_icon
+
+    @app_icon.setter
+    def app_icon(self, value: Icon | None) -> None:
+        self._async_api.app_icon = value
 
     def request_authorisation(self) -> bool:
         """See :meth:`desktop_notifier.main.DesktopNotifier.request_authorisation`"""


### PR DESCRIPTION
This truly freezes Notification instances

`Resource.as_name()` is necessary to make `mypy` happy, otherwise it always assumes that `Resource.name` might be `None`