### PR TITLE
Quality of life improvements to Notification class

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ requires-python = ">=3.9"
 dependencies = [
     "bidict",
     "packaging",
+    "immutabledict",
     "dbus-fast;sys_platform=='linux'",
     "rubicon-objc;sys_platform=='darwin'",
     "winrt-windows.applicationmodel.core;sys_platform=='win32'",

--- a/src/desktop_notifier/backends/base.py
+++ b/src/desktop_notifier/backends/base.py
@@ -176,8 +176,8 @@ class DesktopNotifierBackend(ABC):
         button_identifier: str,
         notification: Notification | None = None,
     ) -> None:
-        if notification and button_identifier in notification._buttons_dict:
-            button = notification._buttons_dict[button_identifier]
+        if notification and button_identifier in notification.buttons_dict:
+            button = notification.buttons_dict[button_identifier]
         else:
             button = None
 

--- a/src/desktop_notifier/common.py
+++ b/src/desktop_notifier/common.py
@@ -207,36 +207,36 @@ class Notification:
     message: str
     """Notification message"""
 
-    urgency: Urgency = Urgency.Normal
+    urgency: Urgency = field(default=Urgency.Normal, repr=False)
     """Notification urgency. Can determine stickiness, notification appearance and
     break through silencing."""
 
-    icon: Icon | None = None
+    icon: Icon | None = field(default=None, repr=False)
     """Icon to use for the notification"""
 
-    buttons: tuple[Button, ...] = field(default_factory=tuple)
+    buttons: tuple[Button, ...] = field(default_factory=tuple, repr=False)
     """Buttons shown on an interactive notification"""
 
-    reply_field: ReplyField | None = None
+    reply_field: ReplyField | None = field(default=None, repr=False)
     """Text field shown on an interactive notification. This can be used for example
     for messaging apps to reply directly from the notification."""
 
-    on_clicked: Callable[[], Any] | None = None
+    on_clicked: Callable[[], Any] | None = field(default=None, repr=False)
     """Method to call when the notification is clicked"""
 
-    on_dismissed: Callable[[], Any] | None = None
+    on_dismissed: Callable[[], Any] | None = field(default=None, repr=False)
     """Method to call when the notification is dismissed"""
 
-    attachment: Attachment | None = None
+    attachment: Attachment | None = field(default=None, repr=False)
     """A file attached to the notification which may be displayed as a preview"""
 
-    sound: Sound | None = None
+    sound: Sound | None = field(default=None, repr=False)
     """A sound to play on notification"""
 
-    thread: str | None = None
+    thread: str | None = field(default=None, repr=False)
     """An identifier to group related notifications together, e.g., from a chat space"""
 
-    timeout: int = -1
+    timeout: int = field(default=-1, repr=False)
     """Duration in seconds for which the notification is shown"""
 
     identifier: str = field(default_factory=uuid_str)
@@ -248,12 +248,6 @@ class Notification:
     def __post_init__(self) -> None:
         for button in self.buttons:
             self._buttons_dict[button.identifier] = button
-
-    def __repr__(self) -> str:
-        return (
-            f"<{self.__class__.__name__}(identifier='{self.identifier}', "
-            f"title='{self.title}', message='{self.message}')>"
-        )
 
 
 class Capability(Enum):

--- a/src/desktop_notifier/common.py
+++ b/src/desktop_notifier/common.py
@@ -14,6 +14,8 @@ from pathlib import Path
 from typing import Any, Callable
 from urllib.parse import unquote, urlparse
 
+from immutabledict import immutabledict
+
 __all__ = [
     "Capability",
     "FileResource",
@@ -217,6 +219,11 @@ class Notification:
     buttons: tuple[Button, ...] = field(default_factory=tuple, repr=False)
     """Buttons shown on an interactive notification"""
 
+    buttons_dict: immutabledict[str, Button] = field(
+        default_factory=immutabledict, init=False, repr=False, compare=False
+    )
+    """Buttons shown on an interactive notification, indexed by button identifier"""
+
     reply_field: ReplyField | None = field(default=None, repr=False)
     """Text field shown on an interactive notification. This can be used for example
     for messaging apps to reply directly from the notification."""
@@ -243,11 +250,12 @@ class Notification:
     """A unique identifier for this notification. Generated automatically if not
     passed by the client."""
 
-    _buttons_dict: dict[str, Button] = field(default_factory=dict)
-
     def __post_init__(self) -> None:
-        for button in self.buttons:
-            self._buttons_dict[button.identifier] = button
+        object.__setattr__(
+            self,
+            "buttons_dict",
+            immutabledict({button.identifier: button for button in self.buttons}),
+        )
 
 
 class Capability(Enum):

--- a/src/desktop_notifier/common.py
+++ b/src/desktop_notifier/common.py
@@ -172,6 +172,10 @@ class Button:
     identifier: str = dataclasses.field(default_factory=uuid_str)
     """A unique identifier to use in callbacks to specify with button was clicked"""
 
+    def __post_init__(self) -> None:
+        if self.identifier is None:
+            object.__setattr__(self, "identifier", uuid_str())
+
 
 @dataclass(frozen=True)
 class ReplyField:
@@ -251,6 +255,9 @@ class Notification:
     passed by the client."""
 
     def __post_init__(self) -> None:
+        if self.identifier is None:
+            object.__setattr__(self, "identifier", uuid_str())
+
         object.__setattr__(
             self,
             "buttons_dict",


### PR DESCRIPTION
* Remove `Notification.__repr__()`, utilize native `__repr__` of `@dataclass` instead
* Make `Notification._buttons_dict` public, utilize `immutabledict` for that
* Allow initializing `Notification` and `Button` with `identifier=None`

Off topic: One can tell that `@dataclass` was designed without typing in mind... Without typing one would simply change `Notification.buttons` directly to a dict and just accept a list in `__init__`... But with typing that's not possible unless we implement `__init__` manually, defying the purpose of `@dataclass`.