### PR TITLE
DesktopNotifierBackend: Drop `notification` param from `handle_*()` methods

### DIFF
--- a/src/desktop_notifier/backends/base.py
+++ b/src/desktop_notifier/backends/base.py
@@ -69,7 +69,7 @@ class DesktopNotifierBackend(ABC):
             logger.debug("Notification sent: %s", notification)
             self._notification_cache[notification.identifier] = notification
 
-            self.handle_dispatched(notification.identifier, notification)
+            self.handle_dispatched(notification.identifier)
 
     def _clear_notification_from_cache(self, identifier: str) -> Notification | None:
         """
@@ -146,54 +146,45 @@ class DesktopNotifierBackend(ABC):
         """
         ...
 
-    def handle_dispatched(
-        self, identifier: str, notification: Notification | None = None
-    ) -> None:
-        if notification and notification.on_dispatched:
-            notification.on_dispatched()
-        elif self.on_dispatched:
+    def handle_dispatched(self, identifier: str) -> None:
+        if identifier in self._notification_cache:
+            notification = self._notification_cache[identifier]
+            if notification.on_dispatched:
+                notification.on_dispatched()
+                return
+        if self.on_dispatched:
             self.on_dispatched(identifier)
 
-    def handle_clicked(
-        self, identifier: str, notification: Notification | None = None
-    ) -> None:
+    def handle_clicked(self, identifier: str) -> None:
+        notification = self._clear_notification_from_cache(identifier)
         if notification and notification.on_clicked:
             notification.on_clicked()
         elif self.on_clicked:
             self.on_clicked(identifier)
 
-    def handle_dismissed(
-        self, identifier: str, notification: Notification | None = None
-    ) -> None:
+    def handle_dismissed(self, identifier: str) -> None:
+        notification = self._clear_notification_from_cache(identifier)
         if notification and notification.on_dismissed:
             notification.on_dismissed()
         elif self.on_dismissed:
             self.on_dismissed(identifier)
 
-    def handle_replied(
-        self, identifier: str, reply_text: str, notification: Notification | None = None
-    ) -> None:
-        if (
-            notification
-            and notification.reply_field
-            and notification.reply_field.on_replied
-        ):
-            notification.reply_field.on_replied(reply_text)
-        elif self.on_replied:
+    def handle_replied(self, identifier: str, reply_text: str) -> None:
+        notification = self._clear_notification_from_cache(identifier)
+        if notification:
+            reply_field = notification.reply_field
+            if reply_field and reply_field.on_replied:
+                reply_field.on_replied(reply_text)
+                return
+        if self.on_replied:
             self.on_replied(identifier, reply_text)
 
-    def handle_button(
-        self,
-        identifier: str,
-        button_identifier: str,
-        notification: Notification | None = None,
-    ) -> None:
+    def handle_button(self, identifier: str, button_identifier: str) -> None:
+        notification = self._clear_notification_from_cache(identifier)
         if notification and button_identifier in notification._buttons_dict:
             button = notification._buttons_dict[button_identifier]
-        else:
-            button = None
-
-        if button and button.on_pressed:
-            button.on_pressed()
-        elif self.on_button_pressed:
+            if button and button.on_pressed:
+                button.on_pressed()
+                return
+        if self.on_button_pressed:
             self.on_button_pressed(identifier, button_identifier)

--- a/src/desktop_notifier/backends/base.py
+++ b/src/desktop_notifier/backends/base.py
@@ -147,12 +147,10 @@ class DesktopNotifierBackend(ABC):
         ...
 
     def handle_dispatched(self, identifier: str) -> None:
-        if identifier in self._notification_cache:
-            notification = self._notification_cache[identifier]
-            if notification.on_dispatched:
-                notification.on_dispatched()
-                return
-        if self.on_dispatched:
+        notification = self._notification_cache.get(identifier)
+        if notification and notification.on_dispatched:
+            notification.on_dispatched()
+        elif self.on_dispatched:
             self.on_dispatched(identifier)
 
     def handle_clicked(self, identifier: str) -> None:

--- a/src/desktop_notifier/backends/dbus.py
+++ b/src/desktop_notifier/backends/dbus.py
@@ -226,16 +226,11 @@ class DBusDesktopNotifier(DesktopNotifierBackend):
             ourselves when scheduling the notification.
         """
         identifier = self._platform_to_interface_notification_identifier.pop(nid, "")
-        notification = self._clear_notification_from_cache(identifier)
-
-        if not notification:
-            return
 
         if action_key == "default":
-            self.handle_clicked(identifier, notification)
-            return
-
-        self.handle_button(identifier, action_key, notification)
+            self.handle_clicked(identifier)
+        else:
+            self.handle_button(identifier, action_key)
 
     def _on_closed(self, nid: int, reason: int) -> None:
         """
@@ -246,13 +241,9 @@ class DBusDesktopNotifier(DesktopNotifierBackend):
         :param reason: An integer describing the reason why the notification was closed.
         """
         identifier = self._platform_to_interface_notification_identifier.pop(nid, "")
-        notification = self._clear_notification_from_cache(identifier)
-
-        if not notification:
-            return
 
         if reason == NOTIFICATION_CLOSED_DISMISSED:
-            self.handle_dismissed(identifier, notification)
+            self.handle_dismissed(identifier)
 
     async def get_capabilities(self) -> frozenset[Capability]:
         if not self.interface:

--- a/src/desktop_notifier/backends/dbus.py
+++ b/src/desktop_notifier/backends/dbus.py
@@ -256,12 +256,7 @@ class DBusDesktopNotifier(DesktopNotifierBackend):
         :param reply_text: The text of the user's reply.
         """
         identifier = self._platform_to_interface_notification_identifier.pop(nid, "")
-        notification = self._clear_notification_from_cache(identifier)
-
-        if not notification:
-            return
-
-        self.handle_replied(identifier, reply_text, notification)
+        self.handle_replied(identifier, reply_text)
 
     def _on_closed(self, nid: int, reason: int) -> None:
         """

--- a/src/desktop_notifier/backends/macos.py
+++ b/src/desktop_notifier/backends/macos.py
@@ -94,21 +94,17 @@ class NotificationCenterDelegate(NSObject):  # type:ignore[misc]
         self, center: objc_id, response: objc_id, completion_handler: objc_block
     ) -> None:
         identifier = py_from_ns(response.notification.request.identifier)
-        notification = self.implementation._clear_notification_from_cache(identifier)
 
         if response.actionIdentifier == UNNotificationDefaultActionIdentifier:
-            self.implementation.handle_clicked(identifier, notification)
-
+            self.implementation.handle_clicked(identifier)
         elif response.actionIdentifier == UNNotificationDismissActionIdentifier:
-            self.implementation.handle_dismissed(identifier, notification)
-
+            self.implementation.handle_dismissed(identifier)
         elif response.actionIdentifier == ReplyActionIdentifier:
             reply_text = py_from_ns(response.userText)
-            self.implementation.handle_replied(identifier, reply_text, notification)
-
+            self.implementation.handle_replied(identifier, reply_text)
         else:
             action_id = py_from_ns(response.actionIdentifier)
-            self.implementation.handle_button(identifier, action_id, notification)
+            self.implementation.handle_button(identifier, action_id)
 
         completion_handler()
 

--- a/src/desktop_notifier/backends/winrt.py
+++ b/src/desktop_notifier/backends/winrt.py
@@ -233,8 +233,6 @@ class WinRTDesktopNotifier(DesktopNotifierBackend):
         if not sender:
             return
 
-        notification = self._clear_notification_from_cache(sender.tag)
-
         if not boxed_activated_args:
             return
 
@@ -242,16 +240,14 @@ class WinRTDesktopNotifier(DesktopNotifierBackend):
         action_id = activated_args.arguments
 
         if action_id == DEFAULT_ACTION:
-            self.handle_clicked(sender.tag, notification)
-
+            self.handle_clicked(sender.tag)
         elif action_id == REPLY_ACTION and activated_args.user_input:
             boxed_reply = activated_args.user_input[REPLY_TEXTBOX_NAME]
             reply = unbox_string(boxed_reply)
-            self.handle_replied(sender.tag, reply, notification)
-
+            self.handle_replied(sender.tag, reply)
         elif action_id.startswith(BUTTON_ACTION_PREFIX):
             button_id = action_id.replace(BUTTON_ACTION_PREFIX, "")
-            self.handle_button(sender.tag, button_id, notification)
+            self.handle_button(sender.tag, button_id)
 
     def _on_dismissed(
         self,
@@ -261,13 +257,11 @@ class WinRTDesktopNotifier(DesktopNotifierBackend):
         if not sender:
             return
 
-        notification = self._clear_notification_from_cache(sender.tag)
-
         if (
             dismissed_args
             and dismissed_args.reason == ToastDismissalReason.USER_CANCELED
         ):
-            self.handle_dismissed(sender.tag, notification)
+            self.handle_dismissed(sender.tag)
 
     def _on_failed(
         self, sender: ToastNotification | None, failed_args: ToastFailedEventArgs | None

--- a/src/desktop_notifier/main.py
+++ b/src/desktop_notifier/main.py
@@ -299,7 +299,10 @@ class DesktopNotifier:
         """
         A method to call when a notification is clicked
 
-        The method must take the notification identifier as a single argument.
+        The method must take the notification identifier as a single argument. You must
+        check whether the given identifier matches any of the notifications you care
+        about, because the notifications server might signal events of other
+        applications as well.
 
         If the notification itself already specifies an on_clicked handler, it will be
         used instead of the class-level handler.
@@ -315,7 +318,10 @@ class DesktopNotifier:
         """
         A method to call when a notification is dismissed
 
-        The method must take the notification identifier as a single argument.
+        The method must take the notification identifier as a single argument. You must
+        check whether the given identifier matches any of the notifications you care
+        about, because the notifications server might signal events of other
+        applications as well.
 
         If the notification itself already specifies an on_dismissed handler, it will be
         used instead of the class-level handler.
@@ -332,7 +338,9 @@ class DesktopNotifier:
         A method to call when one of the notification's buttons is clicked
 
         The method must take the notification identifier and the button identifier as
-        arguments.
+        arguments. You must check whether the given identifier matches any of the
+        notifications you care about, because the notifications server might signal
+        events of other applications as well.
 
         If the notification button itself already specifies an on_pressed handler, it
         will be used instead of the class-level handler.
@@ -349,6 +357,9 @@ class DesktopNotifier:
         A method to call when a user responds through the reply field of a notification
 
         The method must take the notification identifier and input text as arguments.
+        You must check whether the given identifier matches any of the notifications
+        you care about, because the notifications server might signal events of other
+        applications as well.
 
         If the notification's reply field itself already specifies an on_replied
         handler, it will be used instead of the class-level handler.

--- a/src/desktop_notifier/main.py
+++ b/src/desktop_notifier/main.py
@@ -295,13 +295,13 @@ class DesktopNotifier:
         """
         A method to call when a notification is clicked
 
-        The method must take the notification identifier as a single argument. You must
-        check whether the given identifier matches any of the notifications you care
-        about, because the notifications server might signal events of other
-        applications as well.
+        The method must take the notification identifier as a single argument.
 
         If the notification itself already specifies an on_clicked handler, it will be
         used instead of the class-level handler.
+
+        ..note:: On Linux, notifications servers might signal events of other
+          applications as well and will lead to executing this callback.
         """
         return self._backend.on_clicked
 
@@ -314,13 +314,13 @@ class DesktopNotifier:
         """
         A method to call when a notification is dismissed
 
-        The method must take the notification identifier as a single argument. You must
-        check whether the given identifier matches any of the notifications you care
-        about, because the notifications server might signal events of other
-        applications as well.
+        The method must take the notification identifier as a single argument.
 
         If the notification itself already specifies an on_dismissed handler, it will be
         used instead of the class-level handler.
+
+        ..note:: On Linux, notifications servers might signal events of other
+          applications as well and will lead to executing this callback.
         """
         return self._backend.on_dismissed
 
@@ -334,12 +334,13 @@ class DesktopNotifier:
         A method to call when one of the notification's buttons is clicked
 
         The method must take the notification identifier and the button identifier as
-        arguments. You must check whether the given identifier matches any of the
-        notifications you care about, because the notifications server might signal
-        events of other applications as well.
+        arguments.
 
         If the notification button itself already specifies an on_pressed handler, it
         will be used instead of the class-level handler.
+
+        ..note:: On Linux, notifications servers might signal events of other
+          applications as well and will lead to executing this callback.
         """
         return self._backend.on_button_pressed
 
@@ -353,12 +354,12 @@ class DesktopNotifier:
         A method to call when a user responds through the reply field of a notification
 
         The method must take the notification identifier and input text as arguments.
-        You must check whether the given identifier matches any of the notifications
-        you care about, because the notifications server might signal events of other
-        applications as well.
 
         If the notification's reply field itself already specifies an on_replied
         handler, it will be used instead of the class-level handler.
+
+        ..note:: On Linux, notifications servers might signal events of other
+          applications as well and will lead to executing this callback.
         """
         return self._backend.on_replied
 


### PR DESCRIPTION
We don't need the `Notification` instance in the platform-dependant code, thus drop it.

We don't filter notifications on class-level callbacks. Different notifications servers (and versions) signal differently: Some send any signal of any notification to anyone listening, some send signals of all notifications with the same `app_name`, some just the notifications this particular instance dispatched (and here some filter by PID, some by fd). We don't try to be smarter than the notifications server, simply pass everything through. It's up to the user to filter events as needed - or to use the `Notification` instance callbacks instead.