### PR TITLE
Use as_() for correct type inference

### DIFF
--- a/src/desktop_notifier/backends/winrt.py
+++ b/src/desktop_notifier/backends/winrt.py
@@ -238,9 +238,7 @@ class WinRTDesktopNotifier(DesktopNotifierBackend):
         if not boxed_activated_args:
             return
 
-        activated_args = ToastActivatedEventArgs._from(  # type:ignore[attr-defined]
-            boxed_activated_args
-        )
+        activated_args = boxed_activated_args.as_(ToastActivatedEventArgs)
         action_id = activated_args.arguments
 
         if action_id == DEFAULT_ACTION:


### PR DESCRIPTION
`as_()` has replaced `_from()` for "casting" WinRT objects to different types.

I just did this in the web editor, so I haven't tested it, but it should avoid the type error that was being ignored.