### PR TITLE
Remove list hack

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,12 +42,12 @@ dependencies = [
     "typing-extensions",
     "dbus-fast;sys_platform=='linux'",
     "rubicon-objc>=0.5;sys_platform=='darwin'",
-    "winrt-runtime>=3,<4;sys_platform=='win32'",
-    "winrt-windows.applicationmodel.core>=3,<4;sys_platform=='win32'",
-    "winrt-windows.data.xml.dom>=3,<4;sys_platform=='win32'",
-    "winrt-windows.foundation>=3,<4;sys_platform=='win32'",
-    "winrt-windows.foundation.collections>=3,<4;sys_platform=='win32'",
-    "winrt-windows.ui.notifications>=3,<4;sys_platform=='win32'",
+    "winrt-runtime>=3.1;sys_platform=='win32'",
+    "winrt-windows.applicationmodel.core>=3.1;sys_platform=='win32'",
+    "winrt-windows.data.xml.dom>=3.1;sys_platform=='win32'",
+    "winrt-windows.foundation>=3.1;sys_platform=='win32'",
+    "winrt-windows.foundation.collections>=3.1;sys_platform=='win32'",
+    "winrt-windows.ui.notifications>=3.1;sys_platform=='win32'",
 ]
 
 [project.readme]

--- a/src/desktop_notifier/backends/winrt.py
+++ b/src/desktop_notifier/backends/winrt.py
@@ -304,9 +304,7 @@ class WinRTDesktopNotifier(DesktopNotifierBackend):
     async def get_current_notifications(self) -> list[str]:
         if self.manager.history:
             notifications = self.manager.history.get_history_with_id(self.app_id)
-            # Convert winrt IVectorView to list because the former does crashes on list
-            # comprehension on some Python versions.
-            return [n.tag for n in list(notifications)]
+            return [n.tag for n in notifications]
         return await super().get_current_notifications()
 
     async def get_capabilities(self) -> frozenset[Capability]:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,5 +1,4 @@
 import asyncio
-import sys
 import time
 from pathlib import Path
 
@@ -129,10 +128,6 @@ async def test_attachment_uri(notifier: DesktopNotifier) -> None:
 
 
 @pytest.mark.asyncio
-@pytest.mark.skipif(
-    sys.platform.startswith("win"),
-    reason="Clearing individual notifications is broken on Windows",
-)
 async def test_clear(notifier: DesktopNotifier) -> None:
     n0 = await notifier.send(
         title="Julius Caesar",

--- a/tests/test_sync_api.py
+++ b/tests/test_sync_api.py
@@ -1,7 +1,4 @@
-import sys
 import time
-
-import pytest
 
 from desktop_notifier import (
     DEFAULT_SOUND,
@@ -51,10 +48,6 @@ def test_send(notifier_sync: DesktopNotifierSync) -> None:
     assert notification in notifier_sync.get_current_notifications()
 
 
-@pytest.mark.skipif(
-    sys.platform.startswith("win"),
-    reason="Clearing individual notifications is broken on Windows",
-)
 def test_clear(notifier_sync: DesktopNotifierSync) -> None:
     n0 = notifier_sync.send(
         title="Julius Caesar",


### PR DESCRIPTION
I just published PyWinRT v3.1.0 which fixes the crash that was being worked around, so we can drop the hack of casting the return value to a list.

I also removed the upper limit on the package versions. Experience has show than this can cause problems for people trying to use libraries. I don't expect v4 to have breaking API changes like v3 did anyway.

Finally, the Windows tests that were being skipped are passing for me locally, so not sure if that is something that got fixed too or if it depends on the actual Windows version. We'll see if it passes on CI.