### PR TITLE
Linux: add reply field support

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,6 @@
 # v6.2.0
 
-## Added :
+## Added:
 
 * Support for notification reply fields on Linux. Note that this seems to only be
   supported by KNotifications.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,10 @@
+# v6.2.0
+
+## Added :
+
+* Support for notification reply fields on Linux. Note that this seems to only be
+  supported by KNotifications.
+
 # v6.1.1
 
 ## Fixed:

--- a/src/desktop_notifier/backends/dbus.py
+++ b/src/desktop_notifier/backends/dbus.py
@@ -32,6 +32,7 @@ NOTIFICATION_CLOSED_UNDEFINED = 4
 
 DEFAULT_ACTION_KEY = "default"
 INLINE_REPLY_ACTION_KEY = "inline-reply"
+INLINE_REPLY_BUTTON_TEXT_KEY = "x-kde-reply-submit-button-text"
 
 
 class DBusDesktopNotifier(DesktopNotifierBackend):
@@ -91,10 +92,8 @@ class DBusDesktopNotifier(DesktopNotifierBackend):
         if hasattr(self.interface, "on_action_invoked"):
             self.interface.on_action_invoked(self._on_action)
 
-        self.supports_inline_reply = False
         if hasattr(self.interface, "on_notification_replied"):
             self.interface.on_notification_replied(self._on_reply)
-            self.supports_inline_reply = True
 
         return self.interface
 
@@ -117,9 +116,12 @@ class DBusDesktopNotifier(DesktopNotifierBackend):
         for button in notification.buttons:
             actions += [button.identifier, button.title]
 
-        if notification.reply_field and self.supports_inline_reply:
+        if (
+            notification.reply_field
+            and Capability.REPLY_FIELD in await self.get_capabilities()
+        ):
             actions += [INLINE_REPLY_ACTION_KEY, notification.reply_field.title]
-            hints_v["x-kde-reply-submit-button-text"] = Variant(
+            hints_v[INLINE_REPLY_BUTTON_TEXT_KEY] = Variant(
                 "s", notification.reply_field.button_title
             )
 

--- a/tests/backends/dbus.py
+++ b/tests/backends/dbus.py
@@ -43,4 +43,9 @@ def simulate_button_pressed(
 
 
 def simulate_replied(notifier: DesktopNotifier, identifier: str, reply: str) -> None:
-    raise NotImplementedError("Relied callbacks on supported on Linux")
+    assert isinstance(notifier._backend, DBusDesktopNotifier)
+
+    nid = notifier._backend._platform_to_interface_notification_identifier.inverse[
+        identifier
+    ]
+    notifier._backend._on_reply(nid, reply)

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -215,6 +215,8 @@ async def test_button_pressed_fallback_handler_called(
 
 @pytest.mark.asyncio
 async def test_replied_fallback_handler_called(notifier: DesktopNotifier) -> None:
+    await check_supported(notifier, Capability.REPLY_FIELD)
+
     class_handler = Mock()
     notifier.on_replied = class_handler
     notification = Notification(

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -215,8 +215,6 @@ async def test_button_pressed_fallback_handler_called(
 
 @pytest.mark.asyncio
 async def test_replied_fallback_handler_called(notifier: DesktopNotifier) -> None:
-    await check_supported(notifier, Capability.REPLY_FIELD)
-
     class_handler = Mock()
     notifier.on_replied = class_handler
     notification = Notification(


### PR DESCRIPTION
This adds support for the reply field on Linux, using the `inline-reply` capability. It might not exist everywhere but seems to be standard as it doesn't have a `x-vendor` prefix.

Support for the `button_text` field could be achieved, but it doesn't seem to be standardized (yet?), so unsure if this is in the scope of this lib.
![linux_reply_field](https://github.com/user-attachments/assets/807113f4-0d32-4303-8428-ab2eacfb5058)